### PR TITLE
export type support for rmw implementation

### DIFF
--- a/rmw/cmake/get_rmw_typesupport.cmake
+++ b/rmw/cmake/get_rmw_typesupport.cmake
@@ -1,4 +1,4 @@
-# Copyright 2014 Open Source Robotics Foundation, Inc.
+# Copyright 2015 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# copied from rmw/rmw-extras.cmake
+#
+# Get the type support package name for specific ROS middleware implementation.
+#
+# :param rmw_implementation: the package name of the ROS middleware
+#   implementation
+# :type rmw_implementation: string
+#
+# @public
+#
+macro(get_rmw_typesupport var rmw_implementation)
+  if(NOT "${ARGN} " STREQUAL " ")
+    message(FATAL_ERROR "get_rmw_typesupport() called with unused arguments: ${ARGN}")
+  endif()
 
-include("${rmw_DIR}/configure_rmw_library.cmake")
-include("${rmw_DIR}/get_rmw_typesupport.cmake")
-include("${rmw_DIR}/register_rmw_implementation.cmake")
+  ament_index_get_resource(${var} "rmw_implementation" "${rmw_implementation}")
+endmacro()

--- a/rmw/cmake/register_rmw_implementation.cmake
+++ b/rmw/cmake/register_rmw_implementation.cmake
@@ -15,13 +15,17 @@
 #
 # Register the current package as a ROS middleware implementation.
 #
+# :param typesupport_package_name: the package name providing type support for
+#   for the registered RMW implementation
+# :type typesupport_package_name: string
+#
 # @public
 #
-macro(register_rmw_implementation)
+macro(register_rmw_implementation typesupport_package_name)
   if(NOT "${ARGN} " STREQUAL " ")
     message(FATAL_ERROR "register_rmw_implementation() called with "
       "unused arguments: ${ARGN}")
   endif()
 
-  ament_index_register_resource("rmw_implementation")
+  ament_index_register_resource("rmw_implementation" CONTENT "${typesupport_package_name}")
 endmacro()


### PR DESCRIPTION
This is necessary to build libraries / executable against messages / services within the same package.

@esteve @tfoote @wjwwood Please review.