### PR TITLE
fix rmw error strings

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -1,11 +1,15 @@
 cmake_minimum_required(VERSION 2.8.3)
 
-project(rmw NONE)
+project(rmw C)
 
 find_package(ament_cmake REQUIRED)
 
+include_directories(include)
+add_library(${PROJECT_NAME} SHARED "src/error_handling.c")
+
 ament_export_dependencies(rosidl_generator_c)
 ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
 
 if(AMENT_ENABLE_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -21,4 +25,10 @@ install(
 install(
   DIRECTORY include/
   DESTINATION include
+)
+install(
+  TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )

--- a/rmw/src/error_handling.c
+++ b/rmw/src/error_handling.c
@@ -1,4 +1,4 @@
-// Copyright 2014 Open Source Robotics Foundation, Inc.
+// Copyright 2015 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROS_MIDDLEWARE_INTERFACE_ROS_MIDDLEWARE_INTERFACE_ERROR_HANDLING_H_
-#define ROS_MIDDLEWARE_INTERFACE_ROS_MIDDLEWARE_INTERFACE_ERROR_HANDLING_H_
+#include <string.h>
 
-#if __cplusplus
-extern "C"
-{
-#endif
+#include <rmw/error_handling.h>
 
-#include "macros.h"
-#include "visibility_control.h"
+RMW_THREAD_LOCAL char * __rmw_error_string = 0;
 
-RMW_PUBLIC
 void
-rmw_set_error_string(const char * error_string);
-
-RMW_PUBLIC
-const char *
-rmw_get_error_string();
-
-#if __cplusplus
+rmw_set_error_string(const char * error_string)
+{
+  __rmw_error_string = strdup(error_string);
 }
-#endif
 
-#endif  /* ROS_MIDDLEWARE_INTERFACE_ROS_MIDDLEWARE_INTERFACE_ERROR_HANDLING_H_ */
+const char *
+rmw_get_error_string()
+{
+  return __rmw_error_string;
+}


### PR DESCRIPTION
Without the patch if a library like `rmw_connext_cpp` sets the error string another library like `rclcpp` will not be able to retrieve the error string.

Please review.