### PR TITLE
changes to support proper life cycle of rmw objects

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -4,8 +4,11 @@ project(rmw C)
 
 find_package(ament_cmake REQUIRED)
 
+include(cmake/configure_rmw_library.cmake)
+
 include_directories(include)
 add_library(${PROJECT_NAME} SHARED "src/error_handling.c")
+configure_rmw_library(${PROJECT_NAME})
 
 ament_export_dependencies(rosidl_generator_c)
 ament_export_include_directories(include)

--- a/rmw/include/rmw/allocators.h
+++ b/rmw/include/rmw/allocators.h
@@ -77,8 +77,7 @@ RMW_LOCAL
 rmw_subscription_t *
 rmw_subscription_allocate()
 {
-  // Could be overridden with custom (maybe static) subscription
-  // struct allocator
+  // Could be overridden with custom (maybe static) subscription struct allocator
   return (rmw_subscription_t *)rmw_allocate(sizeof(rmw_subscription_t));
 }
 

--- a/rmw/include/rmw/error_handling.h
+++ b/rmw/include/rmw/error_handling.h
@@ -31,6 +31,10 @@ RMW_PUBLIC
 const char *
 rmw_get_error_string();
 
+RMW_PUBLIC
+const char *
+rmw_get_error_string_safe();
+
 #if __cplusplus
 }
 #endif

--- a/rmw/include/rmw/impl/config.h
+++ b/rmw/include/rmw/impl/config.h
@@ -1,4 +1,4 @@
-// Copyright 2015 Open Source Robotics Foundation, Inc.
+// Copyright 2014 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,33 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdlib.h>
-#include <string.h>
+#ifndef RMW_RMW_IMPL_CONFIG_H_
+#define RMW_RMW_IMPL_CONFIG_H_
 
-#include <rmw/error_handling.h>
+#ifndef RMW_AVOID_MEMORY_ALLOCATION
+// Default to off.
+// TODO(wjwwood): document these configuration flags.
+#define RMW_AVOID_MEMORY_ALLOCATION 0
+#endif
 
-RMW_THREAD_LOCAL char * __rmw_error_string = 0;
+#ifndef RMW_REPORT_ERROR_HANDLING_ERRORS
+// Default reporting of error handling errors based on real-time settings.
+// Turn this off to avoid allocation of memory in error handling funcs.
+#define RMW_REPORT_ERROR_HANDLING_ERRORS 1
+#endif
 
-void
-rmw_set_error_string(const char * error_string)
-{
-  if (__rmw_error_string) {
-    free(__rmw_error_string);
-  }
-  __rmw_error_string = strdup(error_string);
-}
-
-const char *
-rmw_get_error_string()
-{
-  return __rmw_error_string;
-}
-
-const char *
-rmw_get_error_string_safe()
-{
-  if (!__rmw_error_string) {
-    return "error string not set";
-  }
-  return __rmw_error_string;
-}
+#endif  /* RMW_RMW_IMPL_CONFIG_H_ */

--- a/rmw/include/rmw/impl/cpp/demangle.hpp
+++ b/rmw/include/rmw/impl/cpp/demangle.hpp
@@ -1,0 +1,60 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_RMW_IMPL_CPP_DEMANGLE_HPP_
+#define RMW_RMW_IMPL_CPP_DEMANGLE_HPP_
+
+#ifndef _WIN32
+// Includes for abi::__cxa_demangle.
+#include <cxxabi.h>
+#include <cstdlib>
+#include <memory>
+#endif
+#include <iostream>
+#include <string>
+
+#include <rmw/impl/config.h>
+
+namespace rmw
+{
+namespace impl
+{
+namespace cpp
+{
+
+template<typename T>
+std::string
+demangle(const T & object)
+{
+// Cannot do demangling if on Windows or if we want to avoid memory allocation.
+#if !defined(_WIN32) || RMW_AVOID_MEMORY_ALLOCATION
+  int status = 0;
+  std::string mangled_typeid_name = typeid(T).name();
+
+  std::unique_ptr<char, void (*)(void *)> res {
+    abi::__cxa_demangle(mangled_typeid_name.c_str(), NULL, NULL, &status),
+    std::free
+  };
+
+  return (status == 0) ? res.get() : mangled_typeid_name;
+#else
+  return typeid(T).name();
+#endif
+}
+
+}  // namespace cpp
+}  // namespace impl
+}  // namespace rmw
+
+#endif  // RMW_RMW_IMPL_CPP_DEMANGLE_HPP_

--- a/rmw/include/rmw/impl/cpp/macros.hpp
+++ b/rmw/include/rmw/impl/cpp/macros.hpp
@@ -1,0 +1,100 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_RMW_IMPL_CPP_MACROS_HPP_
+#define RMW_RMW_IMPL_CPP_MACROS_HPP_
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <rmw/error_handling.h>
+#include <rmw/impl/config.h>  // For RMW_AVOID_MEMORY_ALLOCATION
+#include <rmw/impl/cpp/demangle.hpp>  // For demangle.
+
+// *INDENT-OFF* (prevent uncrustify from using four space indention here)
+#define RMW_TRY_PLACEMENT_NEW(Destination, BufferForNew, FailureAction, Type, ...) try { \
+  Destination = new(BufferForNew) Type(__VA_ARGS__); \
+} catch(const std::exception & exception) { \
+  rmw_set_error_string(( \
+    std::string("caught C++ exception ") + rmw::impl::cpp::demangle(exception) + \
+    " constructing " #Type ": " + exception.what() \
+  ).c_str()); \
+  FailureAction; \
+} catch(...) { \
+  rmw_set_error_string("caught unknown C++ exception constructing " #Type); \
+  FailureAction; \
+}
+
+#define RMW_TRY_DESTRUCTOR(Statement, Type, FailureAction) try { \
+  Statement; \
+} catch(const std::exception & exception) { \
+  rmw_set_error_string(( \
+    std::string("caught C++ exception in destructor of " #Type ": ") + \
+    rmw::impl::cpp::demangle(exception) + ": " + exception.what() \
+  ).c_str()); \
+  FailureAction; \
+} catch(...) { \
+  rmw_set_error_string("caught unknown C++ exception in destructor of " #Type); \
+  FailureAction; \
+}
+
+#define RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(Statement, Type) try { \
+  Statement; \
+} catch(const std::exception & exception) { \
+  std::stringstream ss; \
+  ss << "caught C++ exception in destructor of " #Type " while handling a failure: " \
+     << rmw::impl::cpp::demangle(exception) << ": " << exception.what() \
+     << ", at: " << __FILE__ << ":" << __LINE__ << '\n'; \
+  (std::cerr << ss.str()).flush(); \
+} catch(...) { \
+  std::stringstream ss; \
+  ss << "caught unknown C++ exception in destructor of " #Type \
+     << " while handling a failure at: " << __FILE__ << ":" << __LINE__ << '\n'; \
+  (std::cerr << ss.str()).flush(); \
+}
+
+#if RMW_AVOID_MEMORY_ALLOCATION
+#define RMW_CHECK_TYPE_IDENTIFIERS_MATCH(ElementName, ElementTypeID, ExpectedTypeID, OnFailure) { \
+  if (ElementTypeID != ExpectedTypeID) { \
+    char __msg[1024]; \
+    snprintf( \
+      __msg, 1024, \
+      #ElementName " implementation '%s'(%p) does not match rmw implementation '%s'(%p)", \
+      ElementTypeID, ElementTypeID, ExpectedTypeID, ExpectedTypeID); \
+    rmw_set_error_string(__msg); \
+    OnFailure; \
+  } \
+}
+#else  // RMW_AVOID_MEMORY_ALLOCATION
+#define RMW_CHECK_TYPE_IDENTIFIERS_MATCH(ElementName, ElementTypeID, ExpectedTypeID, OnFailure) { \
+  if (ElementTypeID != ExpectedTypeID) { \
+    size_t __bytes_that_would_have_been_written = snprintf( \
+      NULL, 0, \
+      #ElementName " implementation '%s'(%p) does not match rmw implementation '%s'(%p)", \
+      ElementTypeID, ElementTypeID, ExpectedTypeID, ExpectedTypeID); \
+    char * __msg = (char *)rmw_allocate(__bytes_that_would_have_been_written + 1); \
+    snprintf( \
+      __msg, __bytes_that_would_have_been_written + 1, \
+      #ElementName " implementation '%s'(%p) does not match rmw implementation '%s'(%p)", \
+      ElementTypeID, ElementTypeID, ExpectedTypeID, ExpectedTypeID); \
+    rmw_set_error_string(__msg); \
+    rmw_free(__msg); \
+    OnFailure; \
+  } \
+}
+#endif  // RMW_AVOID_MEMORY_ALLOCATION
+// *INDENT-ON*
+
+#endif  // RMW_RMW_IMPL_CPP_MACROS_HPP_

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -56,7 +56,7 @@ rmw_create_publisher(
 
 RMW_PUBLIC
 rmw_ret_t
-rmw_destroy_publisher(rmw_publisher_t * publisher);
+rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher);
 
 RMW_PUBLIC
 rmw_ret_t
@@ -73,7 +73,7 @@ rmw_create_subscription(
 
 RMW_PUBLIC
 rmw_ret_t
-rmw_destroy_subscription(rmw_subscription_t * subscription);
+rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription);
 
 RMW_PUBLIC
 rmw_ret_t


### PR DESCRIPTION
The most notable change is that I've added the node handle as an argument to the destroy function for publishers and subscribers (it will be needed with server and client as well, but not until other things are fixed).

Otherwise I also added a function to "demangle" c++ symbols so that I can print nicer error messages in the rmw implementations. However, to do this I had to change the "error_handling" file and therefore the library to C++. That's should be ok though since the API remains C only.

Connects ros2/ros2#69