### PR TITLE
add set error msg macro and improve error api

### DIFF
--- a/rmw/include/rmw/error_handling.h
+++ b/rmw/include/rmw/error_handling.h
@@ -20,20 +20,92 @@ extern "C"
 {
 #endif
 
+#include <stddef.h>
+
 #include "macros.h"
 #include "visibility_control.h"
 
+/// Struct which encapsulates the error state set by RMW_SET_ERROR_MSG().
+typedef struct rmw_error_state_t {
+  const char * message;
+  const char * file;
+  size_t line_number;
+} rmw_error_state_t;
+
+/// Set the error message, the file it occurred in, and the line on which it occurred.
+/**
+ * This is not meant to be used directly, but instead via the RMW_SET_ERROR_MSG(msg) macro.
+ *
+ * The error_msg parameter is copied into the interal error storage and must be null terminated.
+ * The file parameter is not copied, but instead is assumed to be a global as it should be set to
+ * the __FILE__ preprocessor literal when used with the RMW_SET_ERROR_MSG macro.
+ * It should also be null terminated.
+ *
+ * \param error_msg The error message to set.
+ * \param file The path to the file in which the error occurred.
+ * \param line_number The line number on which the error occurred.
+ */
 RMW_PUBLIC
 void
-rmw_set_error_string(const char * error_string);
+rmw_set_error_state(const char * error_msg, const char * file, size_t line_number);
 
+/// Set the error message, automatically appending the current file and line number.
+/**
+ * If an error message was previously set, and rmw_reset_error was not called
+ * since, and this library was built with RMW_REPORT_ERROR_HANDLING_ERRORS set
+ * on, then previously set error message will be printed to stderr.
+ * Error state storage is thread local and so all error related functions are also thread local.
+ *
+ * \param msg The error message to be set.
+ */
+#define RMW_SET_ERROR_MSG(msg) rmw_set_error_state(msg, __FILE__, __LINE__);
+
+/// Return true if the error has been set and has not been reset since, otherwise false.
+RMW_PUBLIC
+bool
+rmw_error_is_set();
+
+/// Return a struct with the error message and the file and line number on which is was set.
+/**
+ * The returned pointer will be NULL if no error has been set in this thread.
+ *
+ * The returned pointer is valid until RMW_SET_ERROR_MSG, rmw_set_error_state, or rmw_reset_error
+ * are called in the same thread.
+ *
+ * \return A pointer to the current error state struct.
+ */
+RMW_PUBLIC
+const rmw_error_state_t *
+rmw_get_error_state();
+
+/// Return the error message followed by ', at <file>:<line>' if set, else NULL.
+/**
+ * The returned pointer is valid until RMW_SET_ERROR_MSG, rmw_set_error_state, or rmw_reset_error
+ * are called in the same thread.
+ *
+ * \return The current error string, with file and line number, or NULL if not set.
+ */
 RMW_PUBLIC
 const char *
 rmw_get_error_string();
 
+/// Return the error message followed by ', at <file>:<line>' if set, else "error not set".
+/**
+ * This function is guaranteed to return a valid c-string.
+ *
+ * The returned pointer is valid until RMW_SET_ERROR_MSG, rmw_set_error_state, or rmw_reset_error
+ * are called in the same thread.
+ *
+ * \return The current error string, with file and line number, or "error not set" if not set.
+ */
 RMW_PUBLIC
 const char *
 rmw_get_error_string_safe();
+
+/// Resets the error state by clearing any previously set error state.
+RMW_PUBLIC
+void
+rmw_reset_error();
 
 #if __cplusplus
 }

--- a/rmw/include/rmw/impl/cpp/macros.hpp
+++ b/rmw/include/rmw/impl/cpp/macros.hpp
@@ -27,26 +27,26 @@
 #define RMW_TRY_PLACEMENT_NEW(Destination, BufferForNew, FailureAction, Type, ...) try { \
   Destination = new(BufferForNew) Type(__VA_ARGS__); \
 } catch(const std::exception & exception) { \
-  rmw_set_error_string(( \
+  RMW_SET_ERROR_MSG(( \
     std::string("caught C++ exception ") + rmw::impl::cpp::demangle(exception) + \
     " constructing " #Type ": " + exception.what() \
   ).c_str()); \
   FailureAction; \
 } catch(...) { \
-  rmw_set_error_string("caught unknown C++ exception constructing " #Type); \
+  RMW_SET_ERROR_MSG("caught unknown C++ exception constructing " #Type); \
   FailureAction; \
 }
 
 #define RMW_TRY_DESTRUCTOR(Statement, Type, FailureAction) try { \
   Statement; \
 } catch(const std::exception & exception) { \
-  rmw_set_error_string(( \
+  RMW_SET_ERROR_MSG(( \
     std::string("caught C++ exception in destructor of " #Type ": ") + \
     rmw::impl::cpp::demangle(exception) + ": " + exception.what() \
   ).c_str()); \
   FailureAction; \
 } catch(...) { \
-  rmw_set_error_string("caught unknown C++ exception in destructor of " #Type); \
+  RMW_SET_ERROR_MSG("caught unknown C++ exception in destructor of " #Type); \
   FailureAction; \
 }
 
@@ -73,7 +73,7 @@
       __msg, 1024, \
       #ElementName " implementation '%s'(%p) does not match rmw implementation '%s'(%p)", \
       ElementTypeID, ElementTypeID, ExpectedTypeID, ExpectedTypeID); \
-    rmw_set_error_string(__msg); \
+    RMW_SET_ERROR_MSG(__msg); \
     OnFailure; \
   } \
 }
@@ -89,7 +89,7 @@
       __msg, __bytes_that_would_have_been_written + 1, \
       #ElementName " implementation '%s'(%p) does not match rmw implementation '%s'(%p)", \
       ElementTypeID, ElementTypeID, ExpectedTypeID, ExpectedTypeID); \
-    rmw_set_error_string(__msg); \
+    RMW_SET_ERROR_MSG(__msg); \
     rmw_free(__msg); \
     OnFailure; \
   } \

--- a/rmw/include/rmw/macros.h
+++ b/rmw/include/rmw/macros.h
@@ -21,4 +21,7 @@
   #define RMW_THREAD_LOCAL __thread
 #endif
 
+#define RMW_STRINGIFY_IMPL(x) #x
+#define RMW_STRINGIFY(x) RMW_STRINGIFY_IMPL(x)
+
 #endif  // RMW_RMW_MACROS_H_

--- a/rmw/src/error_handling.c
+++ b/rmw/src/error_handling.c
@@ -12,33 +12,136 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include <string.h>
 
+#include <rmw/allocators.h>
 #include <rmw/error_handling.h>
+#include <rmw/impl/config.h>
+#include <rmw/macros.h>
 
-RMW_THREAD_LOCAL char * __rmw_error_string = 0;
+#define SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), sizeof(msg), stderr)
+
+#ifndef _WIN32
+#define SNPRINTF snprintf
+#else
+#define SNPRINTF _snprintf
+#endif
+
+RMW_THREAD_LOCAL rmw_error_state_t * __rmw_error_state = NULL;
+RMW_THREAD_LOCAL char * __rmw_error_string = NULL;
+
+static const char __error_format_string[] = "%s, at %s:%zu";
 
 void
-rmw_set_error_string(const char * error_string)
+rmw_set_error_state(const char * error_string, const char * file, size_t line_number)
 {
-  if (__rmw_error_string) {
-    free(__rmw_error_string);
+  if (rmw_error_is_set()) {
+#if RMW_REPORT_ERROR_HANDLING_ERRORS
+    fprintf(
+      stderr,
+      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__) "] error string being overwritten: %s\n",
+      rmw_get_error_string_safe());
+#endif
+    rmw_reset_error();
   }
-  __rmw_error_string = strdup(error_string);
+  __rmw_error_state = (rmw_error_state_t *)rmw_allocate(sizeof(rmw_error_state_t));
+  if (!__rmw_error_state) {
+#if RMW_REPORT_ERROR_HANDLING_ERRORS
+    // rmw_allocate failed, but fwrite might work?
+    SAFE_FWRITE_TO_STDERR(
+      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
+      "] failed to allocate memory for the error state struct\n");
+#endif
+    return;
+  }
+  __rmw_error_state->message = (char *)malloc(strlen(error_string));
+  if (!__rmw_error_state->message) {
+#if RMW_REPORT_ERROR_HANDLING_ERRORS
+    // rmw_allocate failed, but fwrite might work?
+    SAFE_FWRITE_TO_STDERR(
+      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
+      "] failed to allocate memory for the error message in the error state struct\n");
+#endif
+    free(__rmw_error_state);
+    __rmw_error_state = NULL;
+    return;
+  }
+  // Cast the const away to set ->message initially.
+  strcpy((char *)__rmw_error_state->message, error_string);
+  __rmw_error_state->file = file;
+  __rmw_error_state->line_number = line_number;
+}
+
+const rmw_error_state_t *
+rmw_get_error_state()
+{
+  return __rmw_error_state;
+}
+
+static void
+format_error_string(char * dst, const rmw_error_state_t * error_state)
+{
+  size_t bytes_it_would_have_written = SNPRINTF(
+    NULL, 0,
+    __error_format_string,
+    error_state->message, error_state->file, error_state->line_number);
+  dst = (char *)rmw_allocate(bytes_it_would_have_written + 1);
+  if (!dst) {
+#if RMW_REPORT_ERROR_HANDLING_ERRORS
+    // rmw_allocate failed, but fwrite might work?
+    SAFE_FWRITE_TO_STDERR(
+      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
+      "] failed to allocate memory for the error string\n");
+#endif
+    return;
+  }
+  SNPRINTF(
+    dst, bytes_it_would_have_written + 1,
+    __error_format_string,
+    error_state->message, error_state->file, error_state->line_number);
+  // The Windows version of snprintf does not null terminate automatically in all cases.
+  dst[bytes_it_would_have_written] = '\0';
 }
 
 const char *
 rmw_get_error_string()
 {
+  if (!__rmw_error_string) {
+    format_error_string(__rmw_error_string, __rmw_error_state);
+  }
   return __rmw_error_string;
+}
+
+bool
+rmw_error_is_set()
+{
+  return __rmw_error_state == NULL;
 }
 
 const char *
 rmw_get_error_string_safe()
 {
-  if (!__rmw_error_string) {
-    return "error string not set";
+  if (!rmw_error_is_set()) {
+    return "error not set";
   }
-  return __rmw_error_string;
+  return rmw_get_error_string();
+}
+
+void
+rmw_reset_error()
+{
+  if (__rmw_error_state) {
+    if (__rmw_error_state->message) {
+      // Cast const away to delete previously allocated memory.
+      rmw_free((char *)__rmw_error_state->message);
+    }
+    rmw_free(__rmw_error_state);
+  }
+  __rmw_error_state = NULL;
+  if (__rmw_error_string) {
+    rmw_free(__rmw_error_string);
+  }
+  __rmw_error_string = NULL;
 }


### PR DESCRIPTION
I've replaced the usage of `rmw_set_error_string` with a macro `RMW_SET_ERROR_MSG` which sets the error state with a new function `rmw_set_error_state(msg, file, line)`. I've tried to use the term error message (msg) when referring to the message the user sets and error string when referring to the formatted error message which includes the file and line number.

I also added some documentation to the error api functions and added some utility functions. I had started an implementation that avoided all memory allocation by using static error storage and truncating messages and file paths if necessary, but I just pushed that to my fork for now. We can revive that if we decide we need alloc free error setting and printing.

Connects to #16