### PR TITLE
add separate macro for visibility of types

### DIFF
--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -28,67 +28,67 @@ typedef int rmw_ret_t;
 #define RMW_RET_OK 0
 #define RMW_RET_ERROR 1
 
-typedef struct RMW_PUBLIC rmw_node_t
+typedef struct RMW_PUBLIC_TYPE rmw_node_t
 {
   const char * implementation_identifier;
   void * data;
 } rmw_node_t;
 
-typedef struct RMW_PUBLIC rmw_publisher_t
+typedef struct RMW_PUBLIC_TYPE rmw_publisher_t
 {
   const char * implementation_identifier;
   void * data;
 } rmw_publisher_t;
 
-typedef struct RMW_PUBLIC rmw_subscription_t
+typedef struct RMW_PUBLIC_TYPE rmw_subscription_t
 {
   const char * implementation_identifier;
   void * data;
 } rmw_subscription_t;
 
-typedef struct RMW_PUBLIC rmw_service_t
+typedef struct RMW_PUBLIC_TYPE rmw_service_t
 {
   const char * implementation_identifier;
   void * data;
 } rmw_service_t;
 
-typedef struct RMW_PUBLIC rmw_client_t
+typedef struct RMW_PUBLIC_TYPE rmw_client_t
 {
   const char * implementation_identifier;
   void * data;
 } rmw_client_t;
 
-typedef struct RMW_PUBLIC rmw_guard_condition_t
+typedef struct RMW_PUBLIC_TYPE rmw_guard_condition_t
 {
   const char * implementation_identifier;
   void * data;
 } rmw_guard_condition_t;
 
-typedef struct RMW_PUBLIC rmw_subscriptions_t
+typedef struct RMW_PUBLIC_TYPE rmw_subscriptions_t
 {
   unsigned long subscriber_count;
   void ** subscribers;
 } rmw_subscriptions_t;
 
-typedef struct RMW_PUBLIC rmw_services_t
+typedef struct RMW_PUBLIC_TYPE rmw_services_t
 {
   unsigned long service_count;
   void ** services;
 } rmw_services_t;
 
-typedef struct RMW_PUBLIC rmw_clients_t
+typedef struct RMW_PUBLIC_TYPE rmw_clients_t
 {
   unsigned long client_count;
   void ** clients;
 } rmw_clients_t;
 
-typedef struct RMW_PUBLIC rmw_guard_conditions_t
+typedef struct RMW_PUBLIC_TYPE rmw_guard_conditions_t
 {
   unsigned long guard_condition_count;
   void ** guard_conditions;
 } rmw_guard_conditions_t;
 
-typedef struct RMW_PUBLIC rmw_request_id_t
+typedef struct RMW_PUBLIC_TYPE rmw_request_id_t
 {
   int8_t writer_guid[16];
   int64_t sequence_number;

--- a/rmw/include/rmw/visibility_control.h
+++ b/rmw/include/rmw/visibility_control.h
@@ -36,6 +36,7 @@ extern "C"
   #else
     #define RMW_PUBLIC RMW_IMPORT
   #endif
+  #define RMW_PUBLIC_TYPE RMW_PUBLIC
   #define RMW_LOCAL
 #else
   #define RMW_EXPORT __attribute__ ((visibility("default")))
@@ -47,6 +48,7 @@ extern "C"
     #define RMW_PUBLIC
     #define RMW_LOCAL
   #endif
+  #define RMW_PUBLIC_TYPE
 #endif
 
 #if __cplusplus


### PR DESCRIPTION
Connects to #24

Fixes the remaining warnings on Linux: http://ci.ros2.org/job/ros2_batch_ci_linux/90/