### PR TITLE
Added system default QoS profile

### DIFF
--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -57,6 +57,13 @@ const static rmw_qos_profile_t rmw_qos_profile_parameter_events =
   RMW_QOS_POLICY_RELIABLE
 };
 
+const static rmw_qos_profile_t rmw_qos_profile_system_default =
+{
+  RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT,
+  RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT,
+  RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT
+};
+
 #if __cplusplus
 }
 #endif

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -130,7 +130,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_topic_names_and_types_t
   char ** type_names;
 } rmw_topic_names_and_types_t;
 
-static const size_t RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT = -1;
+static const size_t RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT = 0;
 
 #if __cplusplus
 }

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -104,12 +104,14 @@ typedef struct RMW_PUBLIC_TYPE rmw_time_t
 
 enum RMW_PUBLIC_TYPE rmw_qos_reliability_policy_t
 {
+  RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT,
   RMW_QOS_POLICY_RELIABLE,
   RMW_QOS_POLICY_BEST_EFFORT
 };
 
 enum RMW_PUBLIC_TYPE rmw_qos_history_policy_t
 {
+  RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT,
   RMW_QOS_POLICY_KEEP_LAST_HISTORY,
   RMW_QOS_POLICY_KEEP_ALL_HISTORY
 };
@@ -127,6 +129,8 @@ typedef struct RMW_PUBLIC_TYPE rmw_topic_names_and_types_t
   char ** topic_names;
   char ** type_names;
 } rmw_topic_names_and_types_t;
+
+static const size_t RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT = -1;
 
 #if __cplusplus
 }


### PR DESCRIPTION
This PR adds support for leaving up to the underlying implementation to use the system default QoS settings.

Connects to ros2/ros2#93