### PR TITLE
remove shared flag from rmw library declaration

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(ament_cmake REQUIRED)
 include(cmake/configure_rmw_library.cmake)
 
 include_directories(include)
-add_library(${PROJECT_NAME} SHARED "src/error_handling.c")
+add_library(${PROJECT_NAME} "src/error_handling.c")
 configure_rmw_library(${PROJECT_NAME})
 
 ament_export_dependencies(rosidl_generator_c)


### PR DESCRIPTION
by removing the SHARED keyword from the add_library call, we can set it externally and thus allow the cmake machinery to select between shared or static builds.
