### PR TITLE
add support for publisher gid's in rmw

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -98,6 +98,15 @@ rmw_take(const rmw_subscription_t * subscription, void * ros_message, bool * tak
 
 RMW_PUBLIC
 RMW_WARN_UNUSED
+rmw_ret_t
+rmw_take_with_info(
+  const rmw_subscription_t * subscription,
+  void * ros_message,
+  bool * taken,
+  rmw_message_info_t * message_info);
+
+RMW_PUBLIC
+RMW_WARN_UNUSED
 rmw_client_t *
 rmw_create_client(
   const rmw_node_t * node,
@@ -209,6 +218,16 @@ rmw_count_subscribers(
   const rmw_node_t * node,
   const char * topic_name,
   size_t * count);
+
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t * gid);
+
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_compare_gids_equal(const rmw_gid_t * gid1, const rmw_gid_t * gid2, bool * result);
 
 #if __cplusplus
 }

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -30,6 +30,10 @@ typedef int rmw_ret_t;
 #define RMW_RET_ERROR 1
 #define RMW_RET_TIMEOUT 2
 
+// 24 bytes is the most memory needed to represent the GID by any current
+// implementation. It may need to be increased in the future.
+#define RMW_GID_STORAGE_SIZE 24
+
 typedef struct RMW_PUBLIC_TYPE rmw_node_t
 {
   const char * implementation_identifier;
@@ -129,6 +133,18 @@ typedef struct RMW_PUBLIC_TYPE rmw_topic_names_and_types_t
   char ** topic_names;
   char ** type_names;
 } rmw_topic_names_and_types_t;
+
+typedef struct RMW_PUBLIC_TYPE rmw_gid_t
+{
+  const char * implementation_identifier;
+  uint8_t data[RMW_GID_STORAGE_SIZE];
+} rmw_gid_t;
+
+typedef struct RMW_PUBLIC_TYPE rmw_message_info_t
+{
+  // const rmw_time_t received_timestamp;
+  rmw_gid_t publisher_gid;
+} rmw_message_info_t;
 
 static const size_t RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT = 0;
 


### PR DESCRIPTION
I am opening this pull request, but it is only part of what is needed for ros2/ros2#91.

Basically it introduces the notion of a GID for publishers in rmw, encapsulated in the `rmw_gid_t`. The `rmw_gid_t` contains only an opaque void pointer, which the implementation can use to compare the GID's in an implementation specific way. You can get the GID of a `rmw_publisher_t` with `rmw_create_gid_from_publisher` and you can get a GID for the sending publisher via `rmw_take_with_gid`. And then you can compare GID's with `rmw_compare_gids_equal`.

Later I can use this to compare the GID of the sender for incoming inter process messages with publishers which are connected via intra process as well and filter those out.

Other ideas for usage and for testing:

- One subscriber is receiving messages from multiple publishers, figure out how many messages have come from each publisher in the subscription callback.
- One publisher and subscription in the same node, you could use this to self filter, ignoring messages from the local publisher.

Please review these changes to the API. I've got an implementation for OpenSplice and I'm starting on Connext/Connext Dynamic. Maybe we can parallelize on those implementations.

Connects to ros2/ros2#91