### PR TITLE
use memset in rmw_allocate

### DIFF
--- a/rmw/include/rmw/allocators.h
+++ b/rmw/include/rmw/allocators.h
@@ -22,6 +22,7 @@ extern "C"
 
 #include <stdlib.h>
 
+#include "string.h"
 #include "types.h"
 #include "visibility_control.h"
 
@@ -30,7 +31,11 @@ void *
 rmw_allocate(size_t size)
 {
   // Could be overridden with a general purpose allocator
-  return malloc(size);
+  void * ptr = malloc(size);
+  if (ptr) {
+    memset(ptr, 0, size);
+  }
+  return ptr;
 }
 
 RMW_LOCAL


### PR DESCRIPTION
In `rmw_allocate`, memset the allocated pointer with zeros.

The rationale for this pull request is:

1) In the general case, initializing malloc'd memory is considered better practice.
2) In real-time computing, accessing the malloc'd memory will map the memory into RAM and the memory management unit, so that accessing the memory will not cause a pagefault later.