### PR TITLE
implement workaround for unresolved symbols problem on Windows

### DIFF
--- a/rmw/package.xml
+++ b/rmw/package.xml
@@ -12,6 +12,8 @@
   <!-- This is required for the definition of the rosidl typesupport types -->
   <build_export_depend>rosidl_generator_c</build_export_depend>
 
+  <build_export_depend>rmw_implementation_cmake</build_export_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/rmw/rmw-extras.cmake
+++ b/rmw/rmw-extras.cmake
@@ -33,7 +33,7 @@ if(WIN32)
   # to build libraries and executables for more than one rmw implementation at a time.
   if(${_len} GREATER 1)
     message(FATAL_ERROR
-      "Only one rmw implementation per workspace is supported on Windows, but ${_len} were found."
+      "Only one rmw implementation per workspace is supported on Windows"
     )
   endif()
   # Use get_default_rmw_implementation to export the default middleware as a transitive dependency.

--- a/rmw/rmw-extras.cmake
+++ b/rmw/rmw-extras.cmake
@@ -17,3 +17,34 @@
 include("${rmw_DIR}/configure_rmw_library.cmake")
 include("${rmw_DIR}/get_rmw_typesupport.cmake")
 include("${rmw_DIR}/register_rmw_implementation.cmake")
+
+# TODO(wjwwood): we have to fix linking with unresolved symbols on Windows before removing this.
+if(WIN32)
+  find_package(ament_cmake REQUIRED)  # Without this find_package(rmw_implementation_cmake) fails.
+  find_package(rmw_implementation_cmake REQUIRED)
+  get_available_rmw_implementations(_rmw_implementations)
+  list(LENGTH _rmw_implementations _len)
+  # If there are no middleware yet, then continue.
+  # This happends when the first middleware implementation is built.
+  if(${_len} EQUAL 0)
+    set(_rmw_implementations)
+    set(_len)
+    return()
+  endif()
+  # Ensure only one middleware is available.
+  # If more than one is available error out in order to prevent other packages from trying
+  # to build libraries and executables for more than one rmw implementation at a time.
+  if(${_len} GREATER 1)
+    message(FATAL_ERROR
+      "Only one rmw implementation per workspace is supported on Windows, but ${_len} were found."
+    )
+  endif()
+  set(_rmw_implementations)
+  set(_len)
+  # Use get_default_rmw_implementation to export the default middleware as a transitive dependency.
+  get_default_rmw_implementation(middleware_implementation)
+  find_package(${middleware_implementation} REQUIRED)
+  list(APPEND rmw_DEFINITIONS ${${middleware_implementation}_DEFINITIONS})
+  list(APPEND rmw_INCLUDE_DIRS ${${middleware_implementation}_INCLUDE_DIRS})
+  list(APPEND rmw_LIBRARIES ${${middleware_implementation}_LIBRARIES})
+endif()

--- a/rmw/rmw-extras.cmake
+++ b/rmw/rmw-extras.cmake
@@ -27,8 +27,6 @@ if(WIN32)
   # If there are no middleware yet, then continue.
   # This happends when the first middleware implementation is built.
   if(${_len} EQUAL 0)
-    set(_rmw_implementations)
-    set(_len)
     return()
   endif()
   # Ensure only one middleware is available.
@@ -39,12 +37,10 @@ if(WIN32)
       "Only one rmw implementation per workspace is supported on Windows, but ${_len} were found."
     )
   endif()
-  set(_rmw_implementations)
-  set(_len)
   # Use get_default_rmw_implementation to export the default middleware as a transitive dependency.
-  get_default_rmw_implementation(middleware_implementation)
-  find_package(${middleware_implementation} REQUIRED)
-  list(APPEND rmw_DEFINITIONS ${${middleware_implementation}_DEFINITIONS})
-  list(APPEND rmw_INCLUDE_DIRS ${${middleware_implementation}_INCLUDE_DIRS})
-  list(APPEND rmw_LIBRARIES ${${middleware_implementation}_LIBRARIES})
+  get_default_rmw_implementation(_middleware_implementation)
+  find_package(${_middleware_implementation} REQUIRED)
+  list(APPEND rmw_DEFINITIONS ${${_middleware_implementation}_DEFINITIONS})
+  list(APPEND rmw_INCLUDE_DIRS ${${_middleware_implementation}_INCLUDE_DIRS})
+  list(APPEND rmw_LIBRARIES ${${_middleware_implementation}_LIBRARIES})
 endif()

--- a/rmw/rmw-extras.cmake
+++ b/rmw/rmw-extras.cmake
@@ -20,7 +20,6 @@ include("${rmw_DIR}/register_rmw_implementation.cmake")
 
 # TODO(wjwwood): we have to fix linking with unresolved symbols on Windows before removing this.
 if(WIN32)
-  find_package(ament_cmake REQUIRED)  # Without this find_package(rmw_implementation_cmake) fails.
   find_package(rmw_implementation_cmake REQUIRED)
   get_available_rmw_implementations(_rmw_implementations)
   list(LENGTH _rmw_implementations _len)

--- a/rmw_implementation_cmake/CMakeLists.txt
+++ b/rmw_implementation_cmake/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+project(rmw_implementation_cmake NONE)
+
+find_package(ament_cmake REQUIRED)
+
+if(AMENT_ENABLE_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package(
+  CONFIG_EXTRAS "rmw_implementation_cmake-extras.cmake"
+)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)

--- a/rmw_implementation_cmake/CMakeLists.txt
+++ b/rmw_implementation_cmake/CMakeLists.txt
@@ -9,6 +9,8 @@ if(AMENT_ENABLE_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+ament_export_dependencies(ament_cmake)
+
 ament_package(
   CONFIG_EXTRAS "rmw_implementation_cmake-extras.cmake"
 )

--- a/rmw_implementation_cmake/cmake/add_executable_for_each_rmw_implementation.cmake
+++ b/rmw_implementation_cmake/cmake/add_executable_for_each_rmw_implementation.cmake
@@ -1,0 +1,81 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add executables using the default rmw implementation as well as each
+# available rmw implementation.
+#
+# The executable using the default rmw implementation has the given target
+# name.
+# The other executables use the target name as the prefix and `__<rmw_name>` as
+# the suffix.
+#
+# :param target: the name of the executable target
+# :type target: string
+# :param ARGN: the source files
+# :type ARGN: list of strings
+# :param TARGET_DEPENDENCIES: the package names passed to
+#   `ament_target_dependencies` for each target
+# :type TARGET_DEPENDENCIES: list of strings
+# :param ALL_TARGET_NAMES_VAR: the output variable name containing all target
+#   names
+# :type ALL_TARGET_NAMES_VAR: string
+# :param SKIP_DEFAULT: if set skip the target without a rmw implementation
+#   suffix
+# :type SKIP_DEFAULT: option
+# :param INSTALL: if set install all executables
+# :type INSTALL: option
+#
+macro(add_executable_for_each_rmw_implementations)
+  # get available rmw implementations
+  get_available_rmw_implementations(_rmw_implementations)
+  foreach(_rmw_implementation ${_rmw_implementations})
+    find_package("${_rmw_implementation}" REQUIRED)
+  endforeach()
+  _add_executable_for_each_rmw_implementations("${_rmw_implementations}" ${ARGN})
+endmacro()
+
+function(_add_executable_for_each_rmw_implementations rmw_implementations target)
+  cmake_parse_arguments(ARG
+    "INSTALL;SKIP_DEFAULT" "ALL_TARGET_NAMES_VAR" "TARGET_DEPENDENCIES" ${ARGN})
+
+  set(targets "")
+  if(NOT ARG_SKIP_DEFAULT)
+    # add executable with the default rmw implementation
+    add_executable(${target} ${ARG_UNPARSED_ARGUMENTS})
+    ament_target_dependencies(${target}
+      "rmw_implementation"
+      ${ARG_TARGET_DEPENDENCIES})
+    if(ARG_INSTALL)
+      install(TARGETS ${target} DESTINATION bin)
+    endif()
+    list(APPEND targets "${target}")
+  endif()
+
+  # add executable for each rmw implementation
+  foreach(rmw_implementation ${rmw_implementations})
+    add_executable(${target}__${rmw_implementation} ${ARG_UNPARSED_ARGUMENTS})
+    ament_target_dependencies(${target}__${rmw_implementation}
+      "${rmw_implementation}"
+      ${ARG_TARGET_DEPENDENCIES})
+    if(ARG_INSTALL)
+      install(TARGETS ${target}__${rmw_implementation} DESTINATION bin)
+    endif()
+    list(APPEND targets "${target}__${rmw_implementation}")
+  endforeach()
+
+  if(ARG_ALL_TARGET_NAMES_VAR)
+    set(${ARG_ALL_TARGET_NAMES_VAR} "${targets}" PARENT_SCOPE)
+  endif()
+endfunction()

--- a/rmw_implementation_cmake/cmake/get_available_rmw_implementations.cmake
+++ b/rmw_implementation_cmake/cmake/get_available_rmw_implementations.cmake
@@ -1,0 +1,27 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Get the package names of the available ROS middleware implemenations.
+#
+# :param var: the output variable name containing the package names
+# :type var: list of strings
+#
+function(get_available_rmw_implementations var)
+  ament_index_get_resources(middleware_implementations "rmw_implementation")
+  if(DEFINED middleware_implementations)
+    list(SORT middleware_implementations)
+  endif()
+  set(${var} ${middleware_implementations} PARENT_SCOPE)
+endfunction()

--- a/rmw_implementation_cmake/cmake/get_default_rmw_implementation.cmake
+++ b/rmw_implementation_cmake/cmake/get_default_rmw_implementation.cmake
@@ -1,0 +1,56 @@
+# Copyright 2014 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Get the package name of the default ROS middleware implemenation.
+#
+# Either selcting it using the variable ROS_MIDDLEWARE_IMPLEMENTATION or
+# choosing a default from the available implementations.
+#
+# :param var: the output variable name containing the package name
+# :type var: string
+#
+macro(get_default_rmw_implementation var)
+  get_available_rmw_implementations(_middleware_implementations)
+
+  if("${_middleware_implementations} " STREQUAL " ")
+    message(FATAL_ERROR "Could not find any ROS middleware implementation.")
+  endif()
+
+  # option()
+  if(NOT "${ROS_MIDDLEWARE_IMPLEMENTATION} " STREQUAL " ")
+    set(_middleware_implementation "${ROS_MIDDLEWARE_IMPLEMENTATION}")
+  elseif(NOT "$ENV{ROS_MIDDLEWARE_IMPLEMENTATION} " STREQUAL " ")
+    set(_middleware_implementation "$ENV{ROS_MIDDLEWARE_IMPLEMENTATION}")
+  else()
+    # TODO detemine "default" implementation based on the available ones
+    list(GET _middleware_implementations 0 _middleware_implementation)
+  endif()
+
+  # verify that the selection one is available
+  list(FIND _middleware_implementations "${_middleware_implementation}" _index)
+  if(_index EQUAL -1)
+    string(REPLACE ";" ", " _middleware_implementations_string "${_middleware_implementations}")
+    message(FATAL_ERROR "Could not find ROS middleware implementation '${_middleware_implementation}'. Choose one of the following: ${_middleware_implementations_string}")
+  endif()
+  find_package("${_middleware_implementation}" REQUIRED)
+
+  # persist implementation decision in cache
+  set(
+    ROS_MIDDLEWARE_IMPLEMENTATION "${_middleware_implementation}"
+    CACHE STRING "Select ROS middleware implementation to link against" FORCE
+  )
+
+  set(${var} ${_middleware_implementation})
+endmacro()

--- a/rmw_implementation_cmake/package.xml
+++ b/rmw_implementation_cmake/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>rmw_implementation_cmake</name>
+  <version>0.0.0</version>
+  <description>
+    CMake functions which can discover and enumerate available implementations.
+  </description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rmw_implementation_cmake/rmw_implementation_cmake-extras.cmake
+++ b/rmw_implementation_cmake/rmw_implementation_cmake-extras.cmake
@@ -14,6 +14,8 @@
 
 # copied from rmw_implementation_cmake/rmw_implementation_cmake-extras.cmake
 
-include("${rmw_implementation_cmake_DIR}/add_executable_for_each_rmw_implementation.cmake")
+include(
+  "${rmw_implementation_cmake_DIR}/add_executable_for_each_rmw_implementation.cmake"
+)
 include("${rmw_implementation_cmake_DIR}/get_available_rmw_implementations.cmake")
 include("${rmw_implementation_cmake_DIR}/get_default_rmw_implementation.cmake")

--- a/rmw_implementation_cmake/rmw_implementation_cmake-extras.cmake
+++ b/rmw_implementation_cmake/rmw_implementation_cmake-extras.cmake
@@ -1,0 +1,19 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# copied from rmw_implementation_cmake/rmw_implementation_cmake-extras.cmake
+
+include("${rmw_implementation_cmake_DIR}/add_executable_for_each_rmw_implementation.cmake")
+include("${rmw_implementation_cmake_DIR}/get_available_rmw_implementations.cmake")
+include("${rmw_implementation_cmake_DIR}/get_default_rmw_implementation.cmake")


### PR DESCRIPTION
Connects to ros2/rclcpp#48

Implements a workaround for the fact that the Windows linker cannot handle unresolved symbols when linking a shared library, see: https://github.com/ros2/rclcpp/issues/48#issuecomment-150714947