### PR TITLE
changes to support rcl refactor

### DIFF
--- a/rmw/include/rmw/error_handling.h
+++ b/rmw/include/rmw/error_handling.h
@@ -20,6 +20,7 @@ extern "C"
 {
 #endif
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #include "rmw/macros.h"

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -190,7 +190,7 @@ rmw_wait(
   rmw_guard_conditions_t * guard_conditions,
   rmw_services_t * services,
   rmw_clients_t * clients,
-  rmw_time_t * wait_timeout);
+  const rmw_time_t * wait_timeout);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -64,7 +64,7 @@ rmw_create_publisher(
   const rmw_node_t * node,
   const rosidl_message_type_support_t * type_support,
   const char * topic_name,
-  const rmw_qos_profile_t & qos_policies = rmw_qos_profile_default);
+  const rmw_qos_profile_t * qos_policies);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED
@@ -83,8 +83,8 @@ rmw_create_subscription(
   const rmw_node_t * node,
   const rosidl_message_type_support_t * type_support,
   const char * topic_name,
-  const rmw_qos_profile_t & qos_policies = rmw_qos_profile_default,
-  bool ignore_local_publications = false);
+  const rmw_qos_profile_t * qos_policies,
+  bool ignore_local_publications);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED
@@ -112,7 +112,7 @@ rmw_create_client(
   const rmw_node_t * node,
   const rosidl_service_type_support_t * type_support,
   const char * service_name,
-  const rmw_qos_profile_t & qos_policies = rmw_qos_profile_services_default);
+  const rmw_qos_profile_t * qos_policies);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED
@@ -143,7 +143,7 @@ rmw_create_service(
   const rmw_node_t * node,
   const rosidl_service_type_support_t * type_support,
   const char * service_name,
-  const rmw_qos_profile_t & qos_policies = rmw_qos_profile_services_default);
+  const rmw_qos_profile_t * qos_policies);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -39,12 +39,15 @@ typedef struct RMW_PUBLIC_TYPE rmw_node_t
 {
   const char * implementation_identifier;
   void * data;
+  const char * name;
+  const size_t domain_id;
 } rmw_node_t;
 
 typedef struct RMW_PUBLIC_TYPE rmw_publisher_t
 {
   const char * implementation_identifier;
   void * data;
+  const char * topic_name;
 } rmw_publisher_t;
 
 typedef struct RMW_PUBLIC_TYPE rmw_subscription_t

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -160,7 +160,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_message_info_t
   bool from_intra_process;
 } rmw_message_info_t;
 
-static const size_t RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT = 0;
+enum {RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT = 0};
 
 #if __cplusplus
 }

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -54,6 +54,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_subscription_t
 {
   const char * implementation_identifier;
   void * data;
+  const char * topic_name;
 } rmw_subscription_t;
 
 typedef struct RMW_PUBLIC_TYPE rmw_service_t


### PR DESCRIPTION
While testing, I realized that we need to change some things in the `rmw` API to support the rcl library changes. The two biggest changes are to make the API actually C and not C++, and to expose things like the node name and topic names through the rmw  API. Currently I plan to do the latter by putting these fields directly in the rmw struct rather than adding getter and setter functions to the rmw API and making it larger.

This pr is still a work in progress as I discover things in testing. I'll also be opening pr's against all of the current rmw implementations to bring them up to speed, but I am testing locally with opensplice for the time being.

Later, but probably not on the first pass, I think we should make the rmw interface more like the rcl interface in a few ways, for example exposing an allocator option in some places, using a wait set struct, and thorough documentation which considers thread-safety, memory allocation, complex usage, etc...

Connects to ros2/rcl#5