### PR TITLE
Add rmw_waitset_t and create/destroy functions

### DIFF
--- a/rmw/include/rmw/allocators.h
+++ b/rmw/include/rmw/allocators.h
@@ -79,6 +79,14 @@ RMW_PUBLIC
 void
 rmw_service_free(rmw_service_t * service);
 
+RMW_PUBLIC
+rmw_waitset_t *
+rmw_waitset_allocate();
+
+RMW_PUBLIC
+void
+rmw_waitset_free(rmw_waitset_t * waitset);
+
 #if __cplusplus
 }
 #endif

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -182,6 +182,29 @@ RMW_WARN_UNUSED
 rmw_ret_t
 rmw_trigger_guard_condition(const rmw_guard_condition_t * guard_condition);
 
+/// Create a waitset to store conditions that the middleware will block on.
+/**
+ * If max_conditions is 0, the waitset can store an unbounded number of conditions to wait on.
+ * If max_conditions is greater than 0, the number of conditions that can be attached to the
+ * waitset is bounded at max_conditions.
+ * \param[in] fixed_guard_conditions Guard conditions that are attached to the waitset immediately
+ * after initialization and are not removed from the waitset until rmw_destroy_waitset is called.
+ * For example, the guard condition for the CTRL-C signal handler is a "fixed condition".
+ * Must stay valid until rmw_destroy_waitset is called. The caller must keep ownership of the
+ * allocated guard conditions and deallocate them after rmw_destroy_waitset is called.
+ * \param[in] max_conditions The maximum number of conditions that can be attached to the waitset.
+ * \return A pointer to the created waitset, nullptr if an error occurred.
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_waitset_t *
+rmw_create_waitset(rmw_guard_conditions_t * fixed_guard_conditions, size_t max_conditions);
+
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_destroy_waitset(rmw_waitset_t * waitset);
+
 RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_ret_t
@@ -190,6 +213,7 @@ rmw_wait(
   rmw_guard_conditions_t * guard_conditions,
   rmw_services_t * services,
   rmw_clients_t * clients,
+  rmw_waitset_t * waitset,
   const rmw_time_t * wait_timeout);
 
 RMW_PUBLIC

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -99,6 +99,13 @@ typedef struct RMW_PUBLIC_TYPE rmw_guard_conditions_t
   void ** guard_conditions;
 } rmw_guard_conditions_t;
 
+typedef struct RMW_PUBLIC_TYPE rmw_waitset_t
+{
+  const char * implementation_identifier;
+  rmw_guard_conditions_t * fixed_guard_conditions;
+  void * data;
+} rmw_waitset_t;
+
 typedef struct RMW_PUBLIC_TYPE rmw_request_id_t
 {
   int8_t writer_guid[16];

--- a/rmw/src/allocators.c
+++ b/rmw/src/allocators.c
@@ -121,3 +121,17 @@ rmw_service_free(rmw_service_t * service)
   // Should have matching overide with rmw_service_allocate
   rmw_free(service);
 }
+
+rmw_waitset_t *
+rmw_waitset_allocate()
+{
+  // Could be overridden with custom (maybe static) client struct allocator
+  return (rmw_waitset_t *)rmw_allocate(sizeof(rmw_waitset_t));
+}
+
+void
+rmw_waitset_free(rmw_waitset_t * waitset)
+{
+  // Should have matching overide with rmw_waitset_allocate
+  rmw_free(waitset);
+}


### PR DESCRIPTION
Improvements discussed in ros2/rmw_opensplice#96 and offline.

Seeking feedback on this approach before implementing it for Connext.

This API change will allow for several improvements to be made.

- Re-use pre-allocated WaitSet and ConditionSeq in rmw_wait, reducing allocations made at the rmw layer.
- Each Executor can keep a handle on its own WaitSet, allowing for multiple Executors to execute concurrently in their own threads. If a global static WaitSet were to be used in this case, a race condition would occur and the accesses would interfere with each other.
- We could add locking to the WaitSet destructor to prevent the race condition with `trigger_guard_condition`.