### PR TITLE
Fix "function declaration isn't a prototype" warnings

### DIFF
--- a/rmw/include/rmw/allocators.h
+++ b/rmw/include/rmw/allocators.h
@@ -33,7 +33,7 @@ rmw_free(void * pointer);
 
 RMW_PUBLIC
 rmw_node_t *
-rmw_node_allocate();
+rmw_node_allocate(void);
 
 RMW_PUBLIC
 void
@@ -41,7 +41,7 @@ rmw_node_free(rmw_node_t * node);
 
 RMW_PUBLIC
 rmw_publisher_t *
-rmw_publisher_allocate();
+rmw_publisher_allocate(void);
 
 RMW_PUBLIC
 void
@@ -49,7 +49,7 @@ rmw_publisher_free(rmw_publisher_t * publisher);
 
 RMW_PUBLIC
 rmw_subscription_t *
-rmw_subscription_allocate();
+rmw_subscription_allocate(void);
 
 RMW_PUBLIC
 void
@@ -57,7 +57,7 @@ rmw_subscription_free(rmw_subscription_t * subscription);
 
 RMW_PUBLIC
 rmw_guard_condition_t *
-rmw_guard_condition_allocate();
+rmw_guard_condition_allocate(void);
 
 RMW_PUBLIC
 void
@@ -65,7 +65,7 @@ rmw_guard_condition_free(rmw_guard_condition_t * guard_condition);
 
 RMW_PUBLIC
 rmw_client_t *
-rmw_client_allocate();
+rmw_client_allocate(void);
 
 RMW_PUBLIC
 void
@@ -73,7 +73,7 @@ rmw_client_free(rmw_client_t * client);
 
 RMW_PUBLIC
 rmw_service_t *
-rmw_service_allocate();
+rmw_service_allocate(void);
 
 RMW_PUBLIC
 void
@@ -81,7 +81,7 @@ rmw_service_free(rmw_service_t * service);
 
 RMW_PUBLIC
 rmw_waitset_t *
-rmw_waitset_allocate();
+rmw_waitset_allocate(void);
 
 RMW_PUBLIC
 void

--- a/rmw/include/rmw/error_handling.h
+++ b/rmw/include/rmw/error_handling.h
@@ -65,7 +65,7 @@ rmw_set_error_state(const char * error_msg, const char * file, size_t line_numbe
 /// Return true if the error has been set and has not been reset since, otherwise false.
 RMW_PUBLIC
 bool
-rmw_error_is_set();
+rmw_error_is_set(void);
 
 /// Return a struct with the error message and the file and line number on which is was set.
 /**
@@ -78,7 +78,7 @@ rmw_error_is_set();
  */
 RMW_PUBLIC
 const rmw_error_state_t *
-rmw_get_error_state();
+rmw_get_error_state(void);
 
 /// Return the error message followed by ', at <file>:<line>' if set, else NULL.
 /**
@@ -89,7 +89,7 @@ rmw_get_error_state();
  */
 RMW_PUBLIC
 const char *
-rmw_get_error_string();
+rmw_get_error_string(void);
 
 /// Return the error message followed by ', at <file>:<line>' if set, else "error not set".
 /**
@@ -102,12 +102,12 @@ rmw_get_error_string();
  */
 RMW_PUBLIC
 const char *
-rmw_get_error_string_safe();
+rmw_get_error_string_safe(void);
 
 /// Resets the error state by clearing any previously set error state.
 RMW_PUBLIC
 void
-rmw_reset_error();
+rmw_reset_error(void);
 
 #if __cplusplus
 }

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -40,12 +40,12 @@ extern "C"
 RMW_PUBLIC
 RMW_WARN_UNUSED
 const char *
-rmw_get_implementation_identifier();
+rmw_get_implementation_identifier(void);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_ret_t
-rmw_init();
+rmw_init(void);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED
@@ -170,7 +170,7 @@ rmw_send_response(
 RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_guard_condition_t *
-rmw_create_guard_condition();
+rmw_create_guard_condition(void);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED


### PR DESCRIPTION
Fix "function declaration isn't a prototype" warnings