### PR TITLE
Fix recursive error setting

### DIFF
--- a/rmw/src/error_handling.c
+++ b/rmw/src/error_handling.c
@@ -29,6 +29,12 @@ RMW_THREAD_LOCAL char * __rmw_error_string = NULL;
 
 static const char __error_format_string[] = "%s, at %s:%zu";
 
+bool
+__rmw_error_is_set(rmw_error_state_t * error_state);
+
+void
+__rmw_reset_error(rmw_error_state_t * error_state);
+
 void
 rmw_set_error_state(const char * error_string, const char * file, size_t line_number)
 {
@@ -123,9 +129,15 @@ rmw_get_error_string()
 }
 
 bool
+__rmw_error_is_set(rmw_error_state_t * error_state)
+{
+  return error_state != NULL;
+}
+
+bool
 rmw_error_is_set()
 {
-  return __rmw_error_state != NULL;
+  return __rmw_error_is_set(__rmw_error_state);
 }
 
 const char *
@@ -138,7 +150,7 @@ rmw_get_error_string_safe()
 }
 
 void
-rmw_reset_error()
+__rmw_reset_error(rmw_error_state_t * error_state)
 {
   if (__rmw_error_state) {
     if (__rmw_error_state->message) {
@@ -152,4 +164,10 @@ rmw_reset_error()
     rmw_free(__rmw_error_string);
   }
   __rmw_error_string = NULL;
+}
+
+void
+rmw_reset_error()
+{
+  return __rmw_reset_error(__rmw_error_state);
 }

--- a/rmw/src/error_handling.c
+++ b/rmw/src/error_handling.c
@@ -38,15 +38,10 @@ __rmw_reset_error(rmw_error_state_t * error_state);
 void
 rmw_set_error_state(const char * error_string, const char * file, size_t line_number)
 {
-  if (rmw_error_is_set()) {
+  rmw_error_state_t * old_error_state = __rmw_error_state;
 #if RMW_REPORT_ERROR_HANDLING_ERRORS
-    fprintf(
-      stderr,
-      "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__) "] error string being overwritten: %s\n",
-      rmw_get_error_string_safe());
+  const char * old_error_string = rmw_get_error_string_safe();
 #endif
-    rmw_reset_error();
-  }
   __rmw_error_state = (rmw_error_state_t *)rmw_allocate(sizeof(rmw_error_state_t));
   if (!__rmw_error_state) {
 #if RMW_REPORT_ERROR_HANDLING_ERRORS
@@ -62,7 +57,7 @@ rmw_set_error_state(const char * error_string, const char * file, size_t line_nu
   __rmw_error_state->message = (char *)malloc(error_string_length + 1);
   if (!__rmw_error_state->message) {
 #if RMW_REPORT_ERROR_HANDLING_ERRORS
-    // rmw_allocate failed, but fwrite might work?
+    // malloc failed, but fwrite might work?
     SAFE_FWRITE_TO_STDERR(
       "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__)
       "] failed to allocate memory for the error message in the error state struct\n");
@@ -86,6 +81,18 @@ rmw_set_error_state(const char * error_string, const char * file, size_t line_nu
 #endif
   __rmw_error_state->file = file;
   __rmw_error_state->line_number = line_number;
+  if (__rmw_error_is_set(old_error_state)) {
+#if RMW_REPORT_ERROR_HANDLING_ERRORS
+    // Only warn of overwritting if the new error string is different from the old ones.
+    if (error_string != old_error_string && error_string != old_error_state->message) {
+      fprintf(
+        stderr,
+        "[rmw|error_handling.c:" RMW_STRINGIFY(__LINE__) "] error string being overwritten: %s\n",
+        old_error_string);
+    }
+#endif
+    __rmw_reset_error(old_error_state);
+  }
 }
 
 const rmw_error_state_t *
@@ -169,5 +176,5 @@ __rmw_reset_error(rmw_error_state_t * error_state)
 void
 rmw_reset_error()
 {
-  return __rmw_reset_error(__rmw_error_state);
+  __rmw_reset_error(__rmw_error_state);
 }


### PR DESCRIPTION
This changes the way `rmw` error handling works so that recursive calls, i.e. `RMW_SET_ERROR_MSG(rmw_get_error_string_safe());` are allowed.

@tfoote 