### PR TITLE
rework get_rmw_typesupport

### DIFF
--- a/rmw/cmake/get_rmw_typesupport.cmake
+++ b/rmw/cmake/get_rmw_typesupport.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015 Open Source Robotics Foundation, Inc.
+# Copyright 2015-2016 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,30 +13,29 @@
 # limitations under the License.
 
 #
-# Get type support package name(s) for specific ROS middleware implementation.
+# Get the type support package names for a specific RMW implementation.
 #
-# :param rmw_implementation: the package name of the ROS middleware
-#   implementation
+# :param var: the output variable name containing the package names
+# :type var: list of strings
+# :param rmw_implementation: the package name of the RMW implementation
 # :type rmw_implementation: string
-# :param language: Optional flag for the language of the type support to get.
-# If language is omitted, type supports for all packages are returned.
-# :type language: string
+# :param LANGUAGE: Optional flag for the language of the type support to get.
+#   If language is omitted, type supports for all packages are returned.
+# :type LANGUAGE: string
 #
 # @public
 #
-macro(get_rmw_typesupport var rmw_implementation)
-  cmake_parse_arguments(_ARG
-    ""
-    "LANGUAGE"
-    ""
-    ${ARGN}
-  )
-  if("${_ARG_LANGUAGE}" STREQUAL "")
-    ament_index_get_resource(${var} "rmw_typesupport" ${rmw_implementation})
-  else()
-    # This output will include type supports the specified language.
-    # The language string should not be case sensitive.
-    string(TOLOWER ${_ARG_LANGUAGE} language_key)
-    ament_index_get_resource(${var} "rmw_typesupport_${language_key}" ${rmw_implementation})
+function(get_rmw_typesupport var rmw_implementation)
+  cmake_parse_arguments(ARG "" "LANGUAGE" "" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "get_rmw_typesupport() called with unused "
+      "arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
-endmacro()
+  set(resource_type "rmw_typesupport")
+  if(NOT "${ARG_LANGUAGE}" STREQUAL "")
+    string(TOLOWER "${ARG_LANGUAGE}" ARG_LANGUAGE)
+    set(resource_type "${resource_type}_${ARG_LANGUAGE}")
+  endif()
+  ament_index_get_resource(resource "${resource_type}" "${rmw_implementation}")
+  set(${var} "${resource}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
@jacquelinekay this is an update for #63 which reworks `get_rmw_typesupport.cmake`.