### PR TITLE
Fix error handling

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -20,7 +20,6 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  enable_language(CXX)
   add_subdirectory(test)
 endif()
 

--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -19,6 +19,9 @@ ament_export_libraries(${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  enable_language(CXX)
+  add_subdirectory(test)
 endif()
 
 ament_package(CONFIG_EXTRAS "rmw-extras.cmake")

--- a/rmw/package.xml
+++ b/rmw/package.xml
@@ -12,6 +12,7 @@
   <!-- This is required for the definition of the rosidl typesupport types -->
   <build_export_depend>rosidl_generator_c</build_export_depend>
 
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/rmw/test/CMakeLists.txt
+++ b/rmw/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+find_package(ament_cmake_gmock REQUIRED)
+
+ament_add_gmock(test_error_handling test_error_handling.cpp)
+target_link_libraries(test_error_handling ${PROJECT_NAME})

--- a/rmw/test/CMakeLists.txt
+++ b/rmw/test/CMakeLists.txt
@@ -1,4 +1,12 @@
+enable_language(CXX)
+
 find_package(ament_cmake_gmock REQUIRED)
 
 ament_add_gmock(test_error_handling test_error_handling.cpp)
-target_link_libraries(test_error_handling ${PROJECT_NAME})
+if(TARGET test_error_handling)
+  target_link_libraries(test_error_handling ${PROJECT_NAME})
+  if(UNIX AND NOT APPLE)
+    target_link_libraries(test_error_handling pthread)
+  endif()
+  set_target_properties(test_error_handling PROPERTIES COMPILE_FLAGS "-std=c++11")
+endif()

--- a/rmw/test/CMakeLists.txt
+++ b/rmw/test/CMakeLists.txt
@@ -2,7 +2,11 @@ enable_language(CXX)
 
 find_package(ament_cmake_gmock REQUIRED)
 
-ament_add_gmock(test_error_handling test_error_handling.cpp)
+ament_add_gmock(test_error_handling
+  test_error_handling.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
 if(TARGET test_error_handling)
   target_link_libraries(test_error_handling ${PROJECT_NAME})
   if(UNIX AND NOT APPLE)

--- a/rmw/test/test_error_handling.cpp
+++ b/rmw/test/test_error_handling.cpp
@@ -1,0 +1,90 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <string>
+
+#include "gmock/gmock.h"
+
+#include "rmw/error_handling.h"
+
+int
+count_substrings(const std::string & str, const std::string & substr)
+{
+    if (substr.length() == 0) {
+      return 0;
+    }
+    int count = 0;
+    for (
+      size_t offset = str.find(substr);
+      offset != std::string::npos;
+      offset = str.find(substr, offset + substr.length()))
+    {
+        ++count;
+    }
+    return count;
+}
+
+TEST(test_error_handling, nominal) {
+  rmw_reset_error();
+  const char * test_message = "test message";
+  RMW_SET_ERROR_MSG(test_message);
+  using ::testing::StartsWith;
+  ASSERT_THAT(rmw_get_error_string_safe(), StartsWith(test_message));
+  rmw_reset_error();
+}
+
+TEST(test_error_handling, reset) {
+  rmw_reset_error();
+  {
+    const char * test_message = "test message";
+    RMW_SET_ERROR_MSG(test_message);
+    using ::testing::StartsWith;
+    ASSERT_THAT(rmw_get_error_string_safe(), StartsWith(test_message));
+  }
+  rmw_reset_error();
+  {
+    const char * test_message = "different message";
+    RMW_SET_ERROR_MSG(test_message);
+    using ::testing::StartsWith;
+    ASSERT_THAT(rmw_get_error_string_safe(), StartsWith(test_message));
+  }
+  rmw_reset_error();
+  ASSERT_EQ(nullptr, rmw_get_error_string());
+  ASSERT_NE(nullptr, rmw_get_error_string_safe());
+  ASSERT_STREQ("error not set", rmw_get_error_string_safe());
+  rmw_reset_error();
+}
+
+TEST(test_error_handling, empty) {
+  rmw_reset_error();
+  ASSERT_EQ(nullptr, rmw_get_error_string());
+  ASSERT_NE(nullptr, rmw_get_error_string_safe());
+  ASSERT_STREQ("error not set", rmw_get_error_string_safe());
+  rmw_reset_error();
+}
+
+TEST(test_error_handling, recursive) {
+  rmw_reset_error();
+  const char * test_message = "test message";
+  RMW_SET_ERROR_MSG(test_message);
+  using ::testing::HasSubstr;
+  ASSERT_THAT(rmw_get_error_string_safe(), HasSubstr(", at"));
+  RMW_SET_ERROR_MSG(rmw_get_error_string_safe());
+  std::string err_msg(rmw_get_error_string_safe());
+  int count = count_substrings(err_msg, ", at");
+  EXPECT_EQ(2, count)
+    << "Expected ', at' in the error string twice but got it '" << count << "': " << err_msg;
+  rmw_reset_error();
+}

--- a/rmw/test/test_error_handling.cpp
+++ b/rmw/test/test_error_handling.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
 #include <string>
 
 #include "gmock/gmock.h"
@@ -22,18 +21,18 @@
 int
 count_substrings(const std::string & str, const std::string & substr)
 {
-    if (substr.length() == 0) {
-      return 0;
-    }
-    int count = 0;
-    for (
-      size_t offset = str.find(substr);
-      offset != std::string::npos;
-      offset = str.find(substr, offset + substr.length()))
-    {
-        ++count;
-    }
-    return count;
+  if (substr.length() == 0) {
+    return 0;
+  }
+  int count = 0;
+  for (
+    size_t offset = str.find(substr);
+    offset != std::string::npos;
+    offset = str.find(substr, offset + substr.length()))
+  {
+    ++count;
+  }
+  return count;
 }
 
 TEST(test_error_handling, nominal) {
@@ -84,7 +83,7 @@ TEST(test_error_handling, recursive) {
   RMW_SET_ERROR_MSG(rmw_get_error_string_safe());
   std::string err_msg(rmw_get_error_string_safe());
   int count = count_substrings(err_msg, ", at");
-  EXPECT_EQ(2, count)
-    << "Expected ', at' in the error string twice but got it '" << count << "': " << err_msg;
+  EXPECT_EQ(2, count) <<
+    "Expected ', at' in the error string twice but got it '" << count << "': " << err_msg;
   rmw_reset_error();
 }


### PR DESCRIPTION
Different fix for ros2/rclcpp#217.

Should effectively replace https://github.com/ros2/rcl/pull/58.

The error state (a struct with the error message, line number, and file separated) was getting reset correctly, but the formatted error message was not. The bug exposed itself as the "error not set" message when an error had been set after another had been set and reset. I also fixed a few other things.

I added tests since it probably would have caught this in the first place. I ran them locally:

```
test 6
    Start 6: test_error_handling

6: Test command: /usr/local/bin/python3 "-u" "/Users/william/ros2_ws/install_isolated/ament_cmake_test/share/ament_cmake_test/cmake/run_test.py" "/Users/william/ros2_ws/build_isolated/rmw/test_results/rmw/test_error_handling.gtest.xml" "--output-file" "/Users/william/ros2_ws/build_isolated/rmw/ament_cmake_gmock/test_error_handling.txt" "--command" "/Users/william/ros2_ws/build_isolated/rmw/test/test_error_handling" "--gtest_output=xml:/Users/william/ros2_ws/build_isolated/rmw/test_results/rmw/test_error_handling.gtest.xml"
6: Test timeout computed to be: 60
6: -- run_test.py: invoking following command in '/Users/william/ros2_ws/src/ros2/rmw/rmw':
6:  - /Users/william/ros2_ws/build_isolated/rmw/test/test_error_handling --gtest_output=xml:/Users/william/ros2_ws/build_isolated/rmw/test_results/rmw/test_error_handling.gtest.xml
6: Running main() from gmock_main.cc
6: [==========] Running 4 tests from 1 test case.
6: [----------] Global test environment set-up.
6: [----------] 4 tests from test_error_handling
6: [ RUN      ] test_error_handling.nominal
6: [       OK ] test_error_handling.nominal (0 ms)
6: [ RUN      ] test_error_handling.reset
6: [       OK ] test_error_handling.reset (0 ms)
6: [ RUN      ] test_error_handling.empty
6: [       OK ] test_error_handling.empty (0 ms)
6: [ RUN      ] test_error_handling.recursive
6: [       OK ] test_error_handling.recursive (0 ms)
6: [----------] 4 tests from test_error_handling (0 ms total)
6:
6: [----------] Global test environment tear-down
6: [==========] 4 tests from 1 test case ran. (0 ms total)
6: [  PASSED  ] 4 tests.
6: -- run_test.py: return code 0
6: -- run_test.py: verify result file '/Users/william/ros2_ws/build_isolated/rmw/test_results/rmw/test_error_handling.gtest.xml'
6/6 Test #6: test_error_handling ..............   Passed    0.15 sec

100% tests passed, 0 tests failed out of 6
```