### PR TITLE
update compiler check to match AppleClang

### DIFF
--- a/rmw/cmake/configure_rmw_library.cmake
+++ b/rmw/cmake/configure_rmw_library.cmake
@@ -37,7 +37,7 @@
 #
 macro(configure_rmw_library library_target)
   # Set the visibility to hidden by default if possible
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # Set the visibility of symbols to hidden by default for gcc and clang
     # (this is already the default on Windows)
     set_target_properties(${library_target}


### PR DESCRIPTION
With using CMake 3.5 and https://cmake.org/cmake/help/v3.0/policy/CMP0025.html we need to match `AppleClang`.

http://ci.ros2.org/job/ci_osx/1176/