### PR TITLE
Add support for pthread-based thread local storage

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -29,6 +29,10 @@ ament_export_dependencies(rosidl_generator_c)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 
+if(IOS AND IOS_SDK_VERSION LESS 10.0)
+  ament_export_libraries(pthread)
+endif()
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -22,7 +22,7 @@ set(rmw_sources
 set_source_files_properties(
   ${rmw_sources}
   PROPERTIES LANGUAGE "C")
-add_library(${PROJECT_NAME} SHARED ${rmw_sources})
+add_library(${PROJECT_NAME} ${rmw_sources})
 configure_rmw_library(${PROJECT_NAME} LANGUAGE "C")
 
 ament_export_dependencies(rosidl_generator_c)

--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -22,7 +22,7 @@ set(rmw_sources
 set_source_files_properties(
   ${rmw_sources}
   PROPERTIES LANGUAGE "C")
-add_library(${PROJECT_NAME} ${rmw_sources})
+add_library(${PROJECT_NAME} SHARED ${rmw_sources})
 configure_rmw_library(${PROJECT_NAME} LANGUAGE "C")
 
 ament_export_dependencies(rosidl_generator_c)

--- a/rmw/include/rmw/macros.h
+++ b/rmw/include/rmw/macros.h
@@ -15,22 +15,36 @@
 #ifndef RMW__MACROS_H_
 #define RMW__MACROS_H_
 
+// This block either sets RMW_THREAD_LOCAL or RMW_THREAD_LOCAL_PTHREAD.
 #if defined _WIN32 || defined __CYGWIN__
+// Windows or Cygwin
   #define RMW_THREAD_LOCAL __declspec(thread)
 #elif defined __APPLE__
-  #include <Availability.h>
-  #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
-    // iOS 10 added support for thread local storage
-    #if __IPHONE_OS_VERSION_MAX_ALLOWED < 100000
-      #define RMW_THREAD_LOCAL_PTHREAD 1
-      #define RMW_THREAD_LOCAL
+// Apple OS's
+  #include <TargetConditionals.h>
+  #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+// iOS Simulator or iOS device
+    #include <Availability.h>
+    #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+      #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
+// iOS >= 10, thread local storage was added in iOS 10
+        #define RMW_THREAD_LOCAL _Thread_local
+      #else
+// iOS < 10, no thread local storage, so use pthread instead
+        #define RMW_THREAD_LOCAL_PTHREAD 1
+        #undef RMW_THREAD_LOCAL
+      #endif
+    #else
+      #error "Unknown iOS version"
     #endif
-  #endif
-
-  #ifndef RMW_THREAD_LOCAL_PTHREAD
+  #elif TARGET_OS_MAC
+// macOS
     #define RMW_THREAD_LOCAL _Thread_local
+  #else
+    #error "Unknown Apple platform"
   #endif
 #else
+// Some other non-Windows, non-cygwin, non-apple OS
   #define RMW_THREAD_LOCAL _Thread_local
 #endif
 

--- a/rmw/include/rmw/macros.h
+++ b/rmw/include/rmw/macros.h
@@ -17,8 +17,21 @@
 
 #if defined _WIN32 || defined __CYGWIN__
   #define RMW_THREAD_LOCAL __declspec(thread)
+#elif defined __APPLE__
+  #include <Availability.h>
+  #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+    // iOS 10 added support for thread local storage
+    #if __IPHONE_OS_VERSION_MAX_ALLOWED < 100000
+      #define RMW_THREAD_LOCAL_PTHREAD 1
+      #define RMW_THREAD_LOCAL
+    #endif
+  #endif
+
+  #ifndef RMW_THREAD_LOCAL_PTHREAD
+    #define RMW_THREAD_LOCAL _Thread_local
+  #endif
 #else
-  #define RMW_THREAD_LOCAL __thread
+  #define RMW_THREAD_LOCAL _Thread_local
 #endif
 
 #define RMW_STRINGIFY_IMPL(x) #x

--- a/rmw/src/error_handling.c
+++ b/rmw/src/error_handling.c
@@ -48,7 +48,8 @@ void
 rmw_set_error_state(const char * error_string, const char * file, size_t line_number)
 {
 #ifdef RMW_THREAD_LOCAL_PTHREAD
-  rmw_error_state_t * __rmw_error_state = (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
+  rmw_error_state_t * __rmw_error_state =
+    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
   char * __rmw_error_string = (char *)pthread_getspecific(__rmw_error_string_key);
 #endif
   rmw_error_state_t * old_error_state = __rmw_error_state;
@@ -127,7 +128,8 @@ static void
 format_error_string()
 {
 #ifdef RMW_THREAD_LOCAL_PTHREAD
-  rmw_error_state_t * __rmw_error_state = (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
+  rmw_error_state_t * __rmw_error_state =
+    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
   char * __rmw_error_string = (char *)pthread_getspecific(__rmw_error_string_key);
 #endif
   if (!__rmw_error_is_set(__rmw_error_state)) {
@@ -180,7 +182,8 @@ bool
 rmw_error_is_set()
 {
 #ifdef RMW_THREAD_LOCAL_PTHREAD
-  rmw_error_state_t * __rmw_error_state = (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
+  rmw_error_state_t * __rmw_error_state =
+    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
 #endif
   return __rmw_error_is_set(__rmw_error_state);
 }
@@ -226,7 +229,8 @@ void
 rmw_reset_error()
 {
 #ifdef RMW_THREAD_LOCAL_PTHREAD
-  rmw_error_state_t * __rmw_error_state = (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
+  rmw_error_state_t * __rmw_error_state =
+    (rmw_error_state_t *)pthread_getspecific(__rmw_error_state_key);
   char * __rmw_error_string = (char *)pthread_getspecific(__rmw_error_string_key);
 #endif
   __rmw_reset_error_string(&__rmw_error_string);


### PR DESCRIPTION
This PR adds support for pthread-based thread local storage on platforms that don't have compiler builtin support for it. I only enabled it for iOS < 10.0, but it can be extended to any other platform via CMake flags.