### PR TITLE
Control shared/static linking via BUILD_SHARED_LIBS

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rmw C)
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 
 include(cmake/configure_rmw_library.cmake)
 
 include_directories(include)
-add_library(${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME}
   "src/allocators.c"
   "src/error_handling.c"
   "src/validate_topic_name.c"

--- a/rmw/package.xml
+++ b/rmw/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <!-- This is required for the definition of the rosidl typesupport types -->
   <build_export_depend>rosidl_generator_c</build_export_depend>


### PR DESCRIPTION
This PR delegates the decision to build a shared or a static library to CMake's BUILD_SHARED_LIBS

Update:

Connects to https://github.com/ros2/ros2/issues/306