### PR TITLE
Update default QoS history to keep last

### DIFF
--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -40,7 +40,7 @@ static const rmw_qos_profile_t rmw_qos_profile_parameters =
 
 static const rmw_qos_profile_t rmw_qos_profile_default =
 {
-  RMW_QOS_POLICY_KEEP_ALL_HISTORY,
+  RMW_QOS_POLICY_KEEP_LAST_HISTORY,
   10,
   RMW_QOS_POLICY_RELIABLE,
   RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT


### PR DESCRIPTION
With keep_all (as is), the depth is ignored (Section `2.2.3.18 HISTORY` of http://www.omg.org/spec/DDS/1.4/PDF) and we have what is akin to an unlimited queue.

This can lead to resource issues (especially using Fast RTPS which has a default history cache size of 5000).

This "addresses" ros2/rmw_fastrtps#68 in the sense that it won't happen using the default QoS settings (it does not fix it because people can still use the QoS settings). 
There is no regression test for ros2/rmw_fastrtps#68, I have only manually confirmed.


Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2004)](http://ci.ros2.org/job/ci_linux/2004/)
OS X: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1535)](http://ci.ros2.org/job/ci_osx/1535/)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1969)](http://ci.ros2.org/job/ci_windows/1969/)