### PR TITLE
don't expose rmw_implementation for now

### DIFF
--- a/rmw_implementation_cmake/cmake/get_available_rmw_implementations.cmake
+++ b/rmw_implementation_cmake/cmake/get_available_rmw_implementations.cmake
@@ -21,6 +21,7 @@
 function(get_available_rmw_implementations var)
   ament_index_get_resources(middleware_implementations "rmw_typesupport")
   if(DEFINED middleware_implementations)
+    list(REMOVE_ITEM middleware_implementations "rmw_implementation")
     list(SORT middleware_implementations)
   endif()
   set(${var} ${middleware_implementations} PARENT_SCOPE)


### PR DESCRIPTION
For now don't generate separate targets and especially tests for `rmw_implementation`. You can remove this locally to e.g. build `talker__rmw_implementation` / `listener__rmw_implementation`.

Connect to ros2/rmw_implementation#17