### PR TITLE
Support node namespaces

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(include)
 add_library(${PROJECT_NAME} SHARED
   "src/allocators.c"
   "src/error_handling.c"
+  "src/validate_namespace.c"
   "src/validate_node_name.c"
   "src/validate_topic_name.c"
   "src/sanity_checks.c")

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -88,7 +88,7 @@ rmw_init(void);
 RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_node_t *
-rmw_create_node(const char * name, const char * name_space, size_t domain_id);
+rmw_create_node(const char * name, const char * namespace_, size_t domain_id);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -88,7 +88,7 @@ rmw_init(void);
 RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_node_t *
-rmw_create_node(const char * name, size_t domain_id);
+rmw_create_node(const char * name, const char * name_space, size_t domain_id);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -45,6 +45,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_node_t
   const char * implementation_identifier;
   void * data;
   const char * name;
+  const char * name_space;
   const size_t domain_id;
 } rmw_node_t;
 

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -45,7 +45,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_node_t
   const char * implementation_identifier;
   void * data;
   const char * name;
-  const char * name_space;
+  const char * namespace_;
   const size_t domain_id;
 } rmw_node_t;
 

--- a/rmw/include/rmw/validate_namespace.h
+++ b/rmw/include/rmw/validate_namespace.h
@@ -1,0 +1,107 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW__VALIDATE_NAMESPACE_H_
+#define RMW__VALIDATE_NAMESPACE_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include "rmw/macros.h"
+#include "rmw/types.h"
+#include "rmw/validate_topic_name.h"
+
+#define RMW_NAMESPACE_VALID 0
+#define RMW_NAMESPACE_INVALID_IS_EMPTY_STRING 1
+#define RMW_NAMESPACE_INVALID_NOT_ABSOLUTE 2
+#define RMW_NAMESPACE_INVALID_ENDS_WITH_FORWARD_SLASH 3
+#define RMW_NAMESPACE_INVALID_CONTAINS_UNALLOWED_CHARACTERS 4
+#define RMW_NAMESPACE_INVALID_CONTAINS_REPEATED_FORWARD_SLASH 5
+#define RMW_NAMESPACE_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER 6
+#define RMW_NAMESPACE_INVALID_TOO_LONG 7
+
+// An additional 2 characters are reserved for the shortest possible topic, e.g. '/X'.
+#define RMW_NAMESPACE_MAX_LENGTH (RMW_TOPIC_MAX_NAME_LENGTH - 2)
+
+/// Determine if a given namespace is valid.
+/** Validity of a namespace is based on rules for a topic defined here:
+ *
+ *   http://design.ros2.org/articles/topic_and_service_names.html
+ *
+ * Note that this function expects that there are no URL suffixes as described
+ * in the above document which can be used for topics and services.
+ *
+ * If either the C string or validation_result pointer are null, then
+ * `RMW_RET_INVALID_ARGUMENT` will be returned.
+ * The namespace_ should be a valid, null-terminated C string.
+ * The validation_result int pointer should point to valid memory so a result
+ * can be stored in it as an output variable.
+ * The invalid_index size_t pointer should point to valid memory so in the
+ * event of a validation error, the location in the input string can be stored
+ * therein.
+ *
+ * The invalid_index will not be assigned a value if the namespace is valid.
+ *
+ * The int which validation_result points to will have a one of a few possible
+ * results values (defined with macros) stored into it:
+ *
+ * - RMW_NAMESPACE_VALID
+ * - RMW_NAMESPACE_INVALID_IS_EMPTY_STRING
+ * - RMW_NAMESPACE_INVALID_NOT_ABSOLUTE
+ * - RMW_NAMESPACE_INVALID_ENDS_WITH_FORWARD_SLASH
+ * - RMW_NAMESPACE_INVALID_CONTAINS_UNALLOWED_CHARACTERS
+ * - RMW_NAMESPACE_INVALID_CONTAINS_REPEATED_FORWARD_SLASH
+ * - RMW_NAMESPACE_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER
+ * - RMW_NAMESPACE_INVALID_TOO_LONG
+ *
+ * The result value can be converted to a description with the
+ * rmw_namespace_validation_result_string() function.
+ *
+ * The ``RMW_NAMESPACE_INVALID_ENDS_WITH_FORWARD_SLASH`` validation result does
+ * not apply to ``"/"``, which is a valid namespace.
+ *
+ * The ``RMW_NAMESPACE_INVALID_TOO_LONG`` is guaranteed to be checked last,
+ * such that if you get that result, then you can assume all other checks
+ * succeeded.
+ * This is done so that the length limit can be treated as a warning rather
+ * than an error if desired.
+ *
+ * \param[in] namespace_ namespace to be validated
+ * \param[out] validation_result int in which the result of the check is stored
+ * \param[out] invalid_index index of the input string where an error occurred
+ * \returns `RMW_RET_OK` on successfully running the check, or
+ * \returns `RMW_RET_INVALID_ARGUMENT` on invalid parameters, or
+ * \returns `RMW_RET_ERROR` when an unspecified error occurs.
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_validate_namespace(
+  const char * namespace_,
+  int * validation_result,
+  size_t * invalid_index);
+
+/// Return a validation result description, or NULL if unknown or RMW_NAMESPACE_VALID.
+RMW_PUBLIC
+RMW_WARN_UNUSED
+const char *
+rmw_namespace_validation_result_string(int validation_result);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RMW__VALIDATE_NAMESPACE_H_

--- a/rmw/include/rmw/validate_namespace.h
+++ b/rmw/include/rmw/validate_namespace.h
@@ -49,9 +49,10 @@ extern "C"
  * The namespace_ should be a valid, null-terminated C string.
  * The validation_result int pointer should point to valid memory so a result
  * can be stored in it as an output variable.
- * The invalid_index size_t pointer should point to valid memory so in the
- * event of a validation error, the location in the input string can be stored
- * therein.
+ * The invalid_index size_t pointer should either point NULL or to valid memory
+ * so in the event of a validation error, the location in the input string can
+ * be stored therein.
+ * If NULL is passed in for invalid_index, it will be not be set.
  *
  * The invalid_index will not be assigned a value if the namespace is valid.
  *

--- a/rmw/include/rmw/validate_node_name.h
+++ b/rmw/include/rmw/validate_node_name.h
@@ -37,7 +37,7 @@ extern "C"
  *
  * - must not be an empty string
  * - must only contain alphanumeric characters and underscores (a-z|A-Z|0-9|_)
- * - must not start with an number
+ * - must start with an alphabetical character
  *
  * If either the node name C string or validation_result pointer are null, then
  * `RMW_RET_INVALID_ARGUMENT` will be returned.

--- a/rmw/include/rmw/validate_node_name.h
+++ b/rmw/include/rmw/validate_node_name.h
@@ -44,9 +44,10 @@ extern "C"
  * The node_name should be a valid, null-terminated C string.
  * The validation_result int pointer should point to valid memory so a result
  * can be stored in it as an output variable.
- * The invalid_index size_t pointer should point to valid memory so in the
- * event of a validation error, the location in the input string can be stored
- * therein.
+ * The invalid_index size_t pointer should either point NULL or to valid memory
+ * so in the event of a validation error, the location in the input string can
+ * be stored therein.
+ * If NULL is passed in for invalid_index, it will be not be set.
  *
  * The invalid_index will not be assigned a value if the node name is valid.
  *

--- a/rmw/include/rmw/validate_node_name.h
+++ b/rmw/include/rmw/validate_node_name.h
@@ -37,7 +37,7 @@ extern "C"
  *
  * - must not be an empty string
  * - must only contain alphanumeric characters and underscores (a-z|A-Z|0-9|_)
- * - must start with an alphabetical character
+ * - must not start with a number
  *
  * If either the node name C string or validation_result pointer are null, then
  * `RMW_RET_INVALID_ARGUMENT` will be returned.

--- a/rmw/include/rmw/validate_topic_name.h
+++ b/rmw/include/rmw/validate_topic_name.h
@@ -56,7 +56,7 @@ extern "C"
  * The int which validation_result points to will have a one of a few possible
  * results values (defined with macros) stored into it:
  *
- * - RMW_VALID_TOPIC
+ * - RMW_TOPIC_VALID
  * - RMW_TOPIC_INVALID_IS_EMPTY_STRING
  * - RMW_TOPIC_INVALID_NOT_ABSOLUTE
  * - RMW_TOPIC_INVALID_ENDS_WITH_FORWARD_SLASH

--- a/rmw/include/rmw/validate_topic_name.h
+++ b/rmw/include/rmw/validate_topic_name.h
@@ -47,9 +47,10 @@ extern "C"
  * The topic_name should be a valid, null-terminated C string.
  * The validation_result int pointer should point to valid memory so a result
  * can be stored in it as an output variable.
- * The invalid_index size_t pointer should point to valid memory so in the
- * event of a validation error, the location in the input string can be stored
- * therein.
+ * The invalid_index size_t pointer should either point NULL or to valid memory
+ * so in the event of a validation error, the location in the input string can
+ * be stored therein.
+ * If NULL is passed in for invalid_index, it will be not be set.
  *
  * The invalid_index will not be assigned a value if the topic is valid.
  *

--- a/rmw/src/validate_namespace.c
+++ b/rmw/src/validate_namespace.c
@@ -1,0 +1,123 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw/validate_namespace.h"
+
+#include <ctype.h>
+#include <string.h>
+
+#include "rmw/error_handling.h"
+#include "rmw/validate_topic_name.h"
+
+#include "./isalnum_no_locale.h"
+
+rmw_ret_t
+rmw_validate_namespace(
+  const char * namespace_,
+  int * validation_result,
+  size_t * invalid_index)
+{
+  if (!namespace_) {
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  if (!validation_result) {
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  if (!invalid_index) {
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+
+  size_t namespace_length = strlen(namespace_);
+  // Special case for root namepsace
+  if (namespace_length == 1 && namespace_[0] == '/') {
+    // Ok to return here, it is valid and will not exceed RMW_NAMESPACE_MAX_LENGTH.
+    *validation_result = RMW_NAMESPACE_VALID;
+    return RMW_RET_OK;
+  }
+
+  // All other cases should pass the validate topic name test.
+  int t_validation_result;
+  size_t t_invalid_index;
+  rmw_ret_t ret = rmw_validate_topic_name(namespace_, &t_validation_result, &t_invalid_index);
+  if (ret != RMW_RET_OK) {
+    // error already set
+    return ret;
+  }
+
+  if (t_validation_result != RMW_TOPIC_VALID && t_validation_result != RMW_TOPIC_INVALID_TOO_LONG) {
+    switch (t_validation_result) {
+      case RMW_TOPIC_INVALID_IS_EMPTY_STRING:
+        *validation_result = RMW_NAMESPACE_INVALID_IS_EMPTY_STRING;
+        break;
+      case RMW_TOPIC_INVALID_NOT_ABSOLUTE:
+        *validation_result = RMW_NAMESPACE_INVALID_NOT_ABSOLUTE;
+        break;
+      case RMW_TOPIC_INVALID_ENDS_WITH_FORWARD_SLASH:
+        *validation_result = RMW_NAMESPACE_INVALID_ENDS_WITH_FORWARD_SLASH;
+        break;
+      case RMW_TOPIC_INVALID_CONTAINS_UNALLOWED_CHARACTERS:
+        *validation_result = RMW_NAMESPACE_INVALID_CONTAINS_UNALLOWED_CHARACTERS;
+        break;
+      case RMW_TOPIC_INVALID_CONTAINS_REPEATED_FORWARD_SLASH:
+        *validation_result = RMW_NAMESPACE_INVALID_CONTAINS_REPEATED_FORWARD_SLASH;
+        break;
+      case RMW_TOPIC_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER:
+        *validation_result = RMW_NAMESPACE_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER;
+        break;
+      default:
+        RMW_SET_ERROR_MSG(
+          "rmw_validate_namespace(): unknown rmw_validate_topic_name() validation result"
+        );
+        return RMW_RET_ERROR;
+    }
+    *invalid_index = t_invalid_index;
+    return RMW_RET_OK;
+  }
+
+  // check if the namespace is too long last, since it might be a soft invalidation
+  if (namespace_length > RMW_NAMESPACE_MAX_LENGTH) {
+    *validation_result = RMW_NAMESPACE_INVALID_TOO_LONG;
+    *invalid_index = RMW_NAMESPACE_MAX_LENGTH - 1;
+    return RMW_RET_OK;
+  }
+
+  // everything was ok, set result to valid namespace, avoid setting invalid_index, and return
+  *validation_result = RMW_NAMESPACE_VALID;
+  return RMW_RET_OK;
+}
+
+const char *
+rmw_namespace_validation_result_string(int validation_result)
+{
+  switch (validation_result) {
+    case RMW_NAMESPACE_VALID:
+      return NULL;
+    case RMW_NAMESPACE_INVALID_IS_EMPTY_STRING:
+      return "namespace must not be empty";
+    case RMW_NAMESPACE_INVALID_NOT_ABSOLUTE:
+      return "namespace must be absolute, it must lead with a '/'";
+    case RMW_NAMESPACE_INVALID_ENDS_WITH_FORWARD_SLASH:
+      return "namespace must not end with a '/', unless only a '/'";
+    case RMW_NAMESPACE_INVALID_CONTAINS_UNALLOWED_CHARACTERS:
+      return "namespace must not contain characters other than alphanumerics, '_', or '/'";
+    case RMW_NAMESPACE_INVALID_CONTAINS_REPEATED_FORWARD_SLASH:
+      return "namespace must not contain repeated '/'";
+    case RMW_NAMESPACE_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER:
+      return "namespace must not have a token that starts with a number";
+    case RMW_NAMESPACE_INVALID_TOO_LONG:
+      return "namespace should not exceed '" RMW_STRINGIFY(RMW_NAMESPACE_MAX_NAME_LENGTH) "'";
+    default:
+      return NULL;
+  }
+}

--- a/rmw/src/validate_namespace.c
+++ b/rmw/src/validate_namespace.c
@@ -27,7 +27,7 @@
   #define LOCAL_SNPRINTF snprintf
 #else
   #define LOCAL_SNPRINTF(buffer, buffer_size, format, ...) \
-    _snprintf_s(buffer, buffer_size, _TRUNCATE, format, __VA_ARGS__)
+  _snprintf_s(buffer, buffer_size, _TRUNCATE, format, __VA_ARGS__)
 #endif
 
 rmw_ret_t

--- a/rmw/src/validate_namespace.c
+++ b/rmw/src/validate_namespace.c
@@ -15,12 +15,19 @@
 #include "rmw/validate_namespace.h"
 
 #include <ctype.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "rmw/error_handling.h"
 #include "rmw/validate_topic_name.h"
 
 #include "./isalnum_no_locale.h"
+
+#ifndef _WIN32
+  #define LOCAL_SNPRINTF snprintf
+#else
+  #define LOCAL_SNPRINTF _snprintf
+#endif
 
 rmw_ret_t
 rmw_validate_namespace(
@@ -73,9 +80,16 @@ rmw_validate_namespace(
         *validation_result = RMW_NAMESPACE_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER;
         break;
       default:
-        RMW_SET_ERROR_MSG(
-          "rmw_validate_namespace(): unknown rmw_validate_topic_name() validation result"
-        );
+        {
+          char default_err_msg[256];
+          // explicitly not taking return value which is number of bytes written
+          LOCAL_SNPRINTF(
+            default_err_msg, sizeof(default_err_msg),
+            "rmw_validate_namespace(): unknown rmw_validate_topic_name() validation result '%d'",
+            *validation_result
+          );
+          RMW_SET_ERROR_MSG(default_err_msg);
+        }
         return RMW_RET_ERROR;
     }
     if (invalid_index) {

--- a/rmw/src/validate_namespace.c
+++ b/rmw/src/validate_namespace.c
@@ -26,7 +26,8 @@
 #ifndef _WIN32
   #define LOCAL_SNPRINTF snprintf
 #else
-  #define LOCAL_SNPRINTF _snprintf
+  #define LOCAL_SNPRINTF(buffer, buffer_size, format, ...) \
+    _snprintf_s(buffer, buffer_size, _TRUNCATE, format, __VA_ARGS__)
 #endif
 
 rmw_ret_t

--- a/rmw/src/validate_namespace.c
+++ b/rmw/src/validate_namespace.c
@@ -34,9 +34,6 @@ rmw_validate_namespace(
   if (!validation_result) {
     return RMW_RET_INVALID_ARGUMENT;
   }
-  if (!invalid_index) {
-    return RMW_RET_INVALID_ARGUMENT;
-  }
 
   size_t namespace_length = strlen(namespace_);
   // Special case for root namepsace
@@ -81,14 +78,18 @@ rmw_validate_namespace(
         );
         return RMW_RET_ERROR;
     }
-    *invalid_index = t_invalid_index;
+    if (invalid_index) {
+      *invalid_index = t_invalid_index;
+    }
     return RMW_RET_OK;
   }
 
   // check if the namespace is too long last, since it might be a soft invalidation
   if (namespace_length > RMW_NAMESPACE_MAX_LENGTH) {
     *validation_result = RMW_NAMESPACE_INVALID_TOO_LONG;
-    *invalid_index = RMW_NAMESPACE_MAX_LENGTH - 1;
+    if (invalid_index) {
+      *invalid_index = RMW_NAMESPACE_MAX_LENGTH - 1;
+    }
     return RMW_RET_OK;
   }
 

--- a/rmw/src/validate_node_name.c
+++ b/rmw/src/validate_node_name.c
@@ -31,13 +31,12 @@ rmw_validate_node_name(
   if (!validation_result) {
     return RMW_RET_INVALID_ARGUMENT;
   }
-  if (!invalid_index) {
-    return RMW_RET_INVALID_ARGUMENT;
-  }
   size_t node_name_length = strlen(node_name);
   if (node_name_length == 0) {
     *validation_result = RMW_NODE_NAME_INVALID_IS_EMPTY_STRING;
-    *invalid_index = 0;
+    if (invalid_index) {
+      *invalid_index = 0;
+    }
     return RMW_RET_OK;
   }
   // check for unallowed characters
@@ -51,20 +50,26 @@ rmw_validate_node_name(
     } else {
       // if it is none of these, then it is an unallowed character in a node name
       *validation_result = RMW_NODE_NAME_INVALID_CONTAINS_UNALLOWED_CHARACTERS;
-      *invalid_index = i;
+      if (invalid_index) {
+        *invalid_index = i;
+      }
       return RMW_RET_OK;
     }
   }
   if (isdigit(node_name[0]) != 0) {
     // this is the case where the name starts with a number, i.e. [0-9]
     *validation_result = RMW_NODE_NAME_INVALID_STARTS_WITH_NUMBER;
-    *invalid_index = 0;
+    if (invalid_index) {
+      *invalid_index = 0;
+    }
     return RMW_RET_OK;
   }
   // check if the node name is too long last, since it might be a soft invalidation
   if (node_name_length > RMW_NODE_NAME_MAX_NAME_LENGTH) {
     *validation_result = RMW_NODE_NAME_INVALID_TOO_LONG;
-    *invalid_index = RMW_NODE_NAME_MAX_NAME_LENGTH - 1;
+    if (invalid_index) {
+      *invalid_index = RMW_NODE_NAME_MAX_NAME_LENGTH - 1;
+    }
     return RMW_RET_OK;
   }
   // everything was ok, set result to valid node name, avoid setting invalid_index, and return

--- a/rmw/src/validate_topic_name.c
+++ b/rmw/src/validate_topic_name.c
@@ -31,25 +31,28 @@ rmw_validate_topic_name(
   if (!validation_result) {
     return RMW_RET_INVALID_ARGUMENT;
   }
-  if (!invalid_index) {
-    return RMW_RET_INVALID_ARGUMENT;
-  }
   size_t topic_name_length = strlen(topic_name);
   if (topic_name_length == 0) {
     *validation_result = RMW_TOPIC_INVALID_IS_EMPTY_STRING;
-    *invalid_index = 0;
+    if (invalid_index) {
+      *invalid_index = 0;
+    }
     return RMW_RET_OK;
   }
   if (topic_name[0] != '/') {
     *validation_result = RMW_TOPIC_INVALID_NOT_ABSOLUTE;
-    *invalid_index = 0;
+    if (invalid_index) {
+      *invalid_index = 0;
+    }
     return RMW_RET_OK;
   }
   // note topic_name_length is >= 1 at this point
   if (topic_name[topic_name_length - 1] == '/') {
     // catches both "/foo/" and "/"
     *validation_result = RMW_TOPIC_INVALID_ENDS_WITH_FORWARD_SLASH;
-    *invalid_index = topic_name_length - 1;
+    if (invalid_index) {
+      *invalid_index = topic_name_length - 1;
+    }
     return RMW_RET_OK;
   }
   // check for unallowed characters
@@ -66,7 +69,9 @@ rmw_validate_topic_name(
     } else {
       // if it is none of these, then it is an unallowed character in a FQN topic name
       *validation_result = RMW_TOPIC_INVALID_CONTAINS_UNALLOWED_CHARACTERS;
-      *invalid_index = i;
+      if (invalid_index) {
+        *invalid_index = i;
+      }
       return RMW_RET_OK;
     }
   }
@@ -80,13 +85,17 @@ rmw_validate_topic_name(
     if (topic_name[i] == '/') {
       if (topic_name[i + 1] == '/') {
         *validation_result = RMW_TOPIC_INVALID_CONTAINS_REPEATED_FORWARD_SLASH;
-        *invalid_index = i + 1;
+        if (invalid_index) {
+          *invalid_index = i + 1;
+        }
         return RMW_RET_OK;
       }
       if (isdigit(topic_name[i + 1]) != 0) {
         // this is the case where a '/' if followed by a number, i.e. [0-9]
         *validation_result = RMW_TOPIC_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER;
-        *invalid_index = i + 1;
+        if (invalid_index) {
+          *invalid_index = i + 1;
+        }
         return RMW_RET_OK;
       }
     }
@@ -94,7 +103,9 @@ rmw_validate_topic_name(
   // check if the topic name is too long last, since it might be a soft invalidation
   if (topic_name_length > RMW_TOPIC_MAX_NAME_LENGTH) {
     *validation_result = RMW_TOPIC_INVALID_TOO_LONG;
-    *invalid_index = RMW_TOPIC_MAX_NAME_LENGTH - 1;
+    if (invalid_index) {
+      *invalid_index = RMW_TOPIC_MAX_NAME_LENGTH - 1;
+    }
     return RMW_RET_OK;
   }
   // everything was ok, set result to valid topic, avoid setting invalid_index, and return

--- a/rmw/test/CMakeLists.txt
+++ b/rmw/test/CMakeLists.txt
@@ -61,3 +61,18 @@ if(TARGET test_validate_node_name)
     set_target_properties(test_validate_node_name PROPERTIES COMPILE_FLAGS "-std=c++14")
   endif()
 endif()
+
+ament_add_gmock(test_validate_namespace
+  test_validate_namespace.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_validate_namespace)
+  target_link_libraries(test_validate_namespace ${PROJECT_NAME})
+  if(UNIX AND NOT APPLE)
+    target_link_libraries(test_validate_namespace pthread)
+  endif()
+  if(NOT WIN32)
+    set_target_properties(test_validate_namespace PROPERTIES COMPILE_FLAGS "-std=c++14")
+  endif()
+endif()

--- a/rmw/test/test_validate_namespace.cpp
+++ b/rmw/test/test_validate_namespace.cpp
@@ -1,0 +1,178 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "gmock/gmock.h"
+
+#include "rmw/validate_namespace.h"
+
+TEST(test_validate_namespace, invalid_parameters) {
+  int validation_result;
+  size_t invalid_index;
+  rmw_ret_t ret = rmw_validate_namespace(nullptr, &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+  ret = rmw_validate_namespace("/test", nullptr, &invalid_index);
+  ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+  ret = rmw_validate_namespace("/test", &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+}
+
+TEST(test_validate_namespace, valid_namespace) {
+  int validation_result;
+  size_t invalid_index;
+  rmw_ret_t ret;
+
+  ret = rmw_validate_namespace("/", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_VALID, validation_result);
+
+  validation_result = -1;
+  ret = rmw_validate_namespace("/basename_only", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_VALID, validation_result);
+
+  validation_result = -1;
+  ret = rmw_validate_namespace("/with_one/heirarchy", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_VALID, validation_result);
+
+  ASSERT_EQ((char *)NULL, rmw_topic_validation_result_string(validation_result));
+}
+
+TEST(test_validate_namespace, empty_namespace) {
+  int validation_result;
+  size_t invalid_index;
+  rmw_ret_t ret;
+
+  ret = rmw_validate_namespace("", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_IS_EMPTY_STRING, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
+  ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
+}
+
+TEST(test_validate_namespace, not_absolute) {
+  int validation_result;
+  size_t invalid_index;
+  rmw_ret_t ret;
+
+  ret = rmw_validate_namespace("not_absolute", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_NOT_ABSOLUTE, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
+  ret = rmw_validate_namespace("not/absolute", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_NOT_ABSOLUTE, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
+  ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
+}
+
+TEST(test_validate_namespace, ends_with_forward_slash) {
+  int validation_result;
+  size_t invalid_index;
+  rmw_ret_t ret;
+
+  ret = rmw_validate_namespace("/ends/with/", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_ENDS_WITH_FORWARD_SLASH, validation_result);
+  ASSERT_EQ(10ul, invalid_index);
+
+  ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
+}
+
+TEST(test_validate_namespace, unallowed_characters) {
+  int validation_result;
+  size_t invalid_index;
+  rmw_ret_t ret;
+
+  ret = rmw_validate_namespace("/~/unexpanded_tilde", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_CONTAINS_UNALLOWED_CHARACTERS, validation_result);
+  ASSERT_EQ(1ul, invalid_index);
+
+  ret = rmw_validate_namespace("/unexpanded_sub/{node}", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_CONTAINS_UNALLOWED_CHARACTERS, validation_result);
+  ASSERT_EQ(16ul, invalid_index);
+
+  ret = rmw_validate_namespace("/question?", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_CONTAINS_UNALLOWED_CHARACTERS, validation_result);
+  ASSERT_EQ(9ul, invalid_index);
+
+  ret = rmw_validate_namespace("/with spaces", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_CONTAINS_UNALLOWED_CHARACTERS, validation_result);
+  ASSERT_EQ(5ul, invalid_index);
+
+  ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
+}
+
+TEST(test_validate_namespace, repeated_forward_slashes) {
+  int validation_result;
+  size_t invalid_index;
+  rmw_ret_t ret;
+
+  ret = rmw_validate_namespace("/repeated//slashes", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_CONTAINS_REPEATED_FORWARD_SLASH, validation_result);
+  ASSERT_EQ(10ul, invalid_index);
+
+  ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
+}
+
+TEST(test_validate_namespace, starts_with_number) {
+  int validation_result;
+  size_t invalid_index;
+  rmw_ret_t ret;
+
+  ret = rmw_validate_namespace("/9starts_with_number", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER, validation_result);
+  ASSERT_EQ(1ul, invalid_index);
+
+  ret = rmw_validate_namespace("/starts/42with/number", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER, validation_result);
+  ASSERT_EQ(8ul, invalid_index);
+
+  ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
+}
+
+TEST(test_validate_namespace, topic_too_long) {
+  int validation_result;
+  size_t invalid_index;
+  rmw_ret_t ret;
+
+  // Ensure the length is not the first error
+  std::string invalid_and_long_topic(RMW_NAMESPACE_MAX_LENGTH + 1, 'a');
+  ret = rmw_validate_namespace(
+    invalid_and_long_topic.c_str(), &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_NOT_ABSOLUTE, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
+  std::string valid_but_long_topic = "/" + invalid_and_long_topic;
+  ret = rmw_validate_namespace(
+    valid_but_long_topic.c_str(), &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  EXPECT_EQ(RMW_NAMESPACE_INVALID_TOO_LONG, validation_result);
+  EXPECT_EQ(RMW_NAMESPACE_MAX_LENGTH - 1, invalid_index);
+
+  ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
+}

--- a/rmw/test/test_validate_namespace.cpp
+++ b/rmw/test/test_validate_namespace.cpp
@@ -25,8 +25,6 @@ TEST(test_validate_namespace, invalid_parameters) {
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
   ret = rmw_validate_namespace("/test", nullptr, &invalid_index);
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
-  ret = rmw_validate_namespace("/test", &validation_result, nullptr);
-  ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
 }
 
 TEST(test_validate_namespace, valid_namespace) {
@@ -48,6 +46,12 @@ TEST(test_validate_namespace, valid_namespace) {
   ASSERT_EQ(RMW_RET_OK, ret);
   ASSERT_EQ(RMW_NAMESPACE_VALID, validation_result);
 
+  // with invalid_index as NULL
+  validation_result = -1;
+  ret = rmw_validate_namespace("/with_one/heirarchy", &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_VALID, validation_result);
+
   ASSERT_EQ((char *)NULL, rmw_topic_validation_result_string(validation_result));
 }
 
@@ -57,6 +61,12 @@ TEST(test_validate_namespace, empty_namespace) {
   rmw_ret_t ret;
 
   ret = rmw_validate_namespace("", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_IS_EMPTY_STRING, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
+  // with invalid_index as NULL
+  ret = rmw_validate_namespace("", &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   ASSERT_EQ(RMW_NAMESPACE_INVALID_IS_EMPTY_STRING, validation_result);
   ASSERT_EQ(0ul, invalid_index);
@@ -79,6 +89,12 @@ TEST(test_validate_namespace, not_absolute) {
   ASSERT_EQ(RMW_NAMESPACE_INVALID_NOT_ABSOLUTE, validation_result);
   ASSERT_EQ(0ul, invalid_index);
 
+  // with invalid_index as NULL
+  ret = rmw_validate_namespace("not/absolute", &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_NOT_ABSOLUTE, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
   ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
 }
 
@@ -88,6 +104,12 @@ TEST(test_validate_namespace, ends_with_forward_slash) {
   rmw_ret_t ret;
 
   ret = rmw_validate_namespace("/ends/with/", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_ENDS_WITH_FORWARD_SLASH, validation_result);
+  ASSERT_EQ(10ul, invalid_index);
+
+  // with invalid_index as NULL
+  ret = rmw_validate_namespace("/ends/with/", &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   ASSERT_EQ(RMW_NAMESPACE_INVALID_ENDS_WITH_FORWARD_SLASH, validation_result);
   ASSERT_EQ(10ul, invalid_index);
@@ -120,6 +142,12 @@ TEST(test_validate_namespace, unallowed_characters) {
   ASSERT_EQ(RMW_NAMESPACE_INVALID_CONTAINS_UNALLOWED_CHARACTERS, validation_result);
   ASSERT_EQ(5ul, invalid_index);
 
+  // with invalid_index as NULL
+  ret = rmw_validate_namespace("/with spaces", &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_CONTAINS_UNALLOWED_CHARACTERS, validation_result);
+  ASSERT_EQ(5ul, invalid_index);
+
   ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
 }
 
@@ -129,6 +157,12 @@ TEST(test_validate_namespace, repeated_forward_slashes) {
   rmw_ret_t ret;
 
   ret = rmw_validate_namespace("/repeated//slashes", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_CONTAINS_REPEATED_FORWARD_SLASH, validation_result);
+  ASSERT_EQ(10ul, invalid_index);
+
+  // with invalid_index as NULL
+  ret = rmw_validate_namespace("/repeated//slashes", &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   ASSERT_EQ(RMW_NAMESPACE_INVALID_CONTAINS_REPEATED_FORWARD_SLASH, validation_result);
   ASSERT_EQ(10ul, invalid_index);
@@ -151,6 +185,12 @@ TEST(test_validate_namespace, starts_with_number) {
   ASSERT_EQ(RMW_NAMESPACE_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER, validation_result);
   ASSERT_EQ(8ul, invalid_index);
 
+  // with invalid_index as NULL
+  ret = rmw_validate_namespace("/starts/42with/number", &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER, validation_result);
+  ASSERT_EQ(8ul, invalid_index);
+
   ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
 }
 
@@ -167,9 +207,23 @@ TEST(test_validate_namespace, topic_too_long) {
   ASSERT_EQ(RMW_NAMESPACE_INVALID_NOT_ABSOLUTE, validation_result);
   ASSERT_EQ(0ul, invalid_index);
 
+  // with invalid_index as NULL
+  ret = rmw_validate_namespace(
+    invalid_and_long_topic.c_str(), &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NAMESPACE_INVALID_NOT_ABSOLUTE, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
   std::string valid_but_long_topic = "/" + invalid_and_long_topic;
   ret = rmw_validate_namespace(
     valid_but_long_topic.c_str(), &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  EXPECT_EQ(RMW_NAMESPACE_INVALID_TOO_LONG, validation_result);
+  EXPECT_EQ(RMW_NAMESPACE_MAX_LENGTH - 1, invalid_index);
+
+  // with invalid_index as NULL
+  ret = rmw_validate_namespace(
+    valid_but_long_topic.c_str(), &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   EXPECT_EQ(RMW_NAMESPACE_INVALID_TOO_LONG, validation_result);
   EXPECT_EQ(RMW_NAMESPACE_MAX_LENGTH - 1, invalid_index);

--- a/rmw/test/test_validate_node_name.cpp
+++ b/rmw/test/test_validate_node_name.cpp
@@ -25,8 +25,6 @@ TEST(test_validate_node_name, invalid_parameters) {
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
   ret = rmw_validate_node_name("test", nullptr, &invalid_index);
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
-  ret = rmw_validate_node_name("test", &validation_result, nullptr);
-  ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
 }
 
 TEST(test_validate_node_name, valid_node_name) {
@@ -43,6 +41,12 @@ TEST(test_validate_node_name, valid_node_name) {
   ASSERT_EQ(RMW_RET_OK, ret);
   ASSERT_EQ(RMW_NODE_NAME_VALID, validation_result);
 
+  // with invalid_index as NULL
+  validation_result = -1;
+  ret = rmw_validate_node_name("node_name", &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NODE_NAME_VALID, validation_result);
+
   ASSERT_EQ((char *)NULL, rmw_node_name_validation_result_string(validation_result));
 }
 
@@ -52,6 +56,12 @@ TEST(test_validate_node_name, empty_node_name) {
   rmw_ret_t ret;
 
   ret = rmw_validate_node_name("", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NODE_NAME_INVALID_IS_EMPTY_STRING, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
+  // with invalid_index as NULL
+  ret = rmw_validate_node_name("", &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   ASSERT_EQ(RMW_NODE_NAME_INVALID_IS_EMPTY_STRING, validation_result);
   ASSERT_EQ(0ul, invalid_index);
@@ -89,6 +99,12 @@ TEST(test_validate_node_name, unallowed_characters) {
   ASSERT_EQ(RMW_NODE_NAME_INVALID_CONTAINS_UNALLOWED_CHARACTERS, validation_result);
   ASSERT_EQ(4ul, invalid_index);
 
+  // with invalid_index as NULL
+  ret = rmw_validate_node_name("with.periods", &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NODE_NAME_INVALID_CONTAINS_UNALLOWED_CHARACTERS, validation_result);
+  ASSERT_EQ(4ul, invalid_index);
+
   ASSERT_NE((char *)NULL, rmw_node_name_validation_result_string(validation_result));
 }
 
@@ -98,6 +114,12 @@ TEST(test_validate_node_name, starts_with_number) {
   rmw_ret_t ret;
 
   ret = rmw_validate_node_name("42node", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NODE_NAME_INVALID_STARTS_WITH_NUMBER, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
+  // with invalid_index as NULL
+  ret = rmw_validate_node_name("42node", &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   ASSERT_EQ(RMW_NODE_NAME_INVALID_STARTS_WITH_NUMBER, validation_result);
   ASSERT_EQ(0ul, invalid_index);
@@ -118,10 +140,24 @@ TEST(test_validate_node_name, node_name_too_long) {
   ASSERT_EQ(RMW_NODE_NAME_INVALID_STARTS_WITH_NUMBER, validation_result);
   ASSERT_EQ(0ul, invalid_index);
 
+  // with invalid_index as NULL
+  ret = rmw_validate_node_name(
+    invalid_and_long_node_name.c_str(), &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_NODE_NAME_INVALID_STARTS_WITH_NUMBER, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
   // Ensure length check works when there are no other issues
   std::string valid_but_long_node_name(RMW_NODE_NAME_MAX_NAME_LENGTH + 1, 'a');
   ret = rmw_validate_node_name(
     valid_but_long_node_name.c_str(), &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  EXPECT_EQ(RMW_NODE_NAME_INVALID_TOO_LONG, validation_result);
+  EXPECT_EQ(RMW_NODE_NAME_MAX_NAME_LENGTH - 1, invalid_index);
+
+  // with invalid_index as NULL
+  ret = rmw_validate_node_name(
+    valid_but_long_node_name.c_str(), &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   EXPECT_EQ(RMW_NODE_NAME_INVALID_TOO_LONG, validation_result);
   EXPECT_EQ(RMW_NODE_NAME_MAX_NAME_LENGTH - 1, invalid_index);

--- a/rmw/test/test_validate_topic_name.cpp
+++ b/rmw/test/test_validate_topic_name.cpp
@@ -25,8 +25,6 @@ TEST(test_validate_topic_name, invalid_parameters) {
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
   ret = rmw_validate_topic_name("test", nullptr, &invalid_index);
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
-  ret = rmw_validate_topic_name("test", &validation_result, nullptr);
-  ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
 }
 
 TEST(test_validate_topic_name, valid_topic) {
@@ -43,6 +41,12 @@ TEST(test_validate_topic_name, valid_topic) {
   ASSERT_EQ(RMW_RET_OK, ret);
   ASSERT_EQ(RMW_TOPIC_VALID, validation_result);
 
+  // with invalid_index as NULL
+  validation_result = -1;
+  ret = rmw_validate_topic_name("/with_one/namespace", &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_TOPIC_VALID, validation_result);
+
   ASSERT_EQ((char *)NULL, rmw_topic_validation_result_string(validation_result));
 }
 
@@ -52,6 +56,12 @@ TEST(test_validate_topic_name, empty_topic_name) {
   rmw_ret_t ret;
 
   ret = rmw_validate_topic_name("", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_TOPIC_INVALID_IS_EMPTY_STRING, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
+  // with invalid_index as NULL
+  ret = rmw_validate_topic_name("", &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   ASSERT_EQ(RMW_TOPIC_INVALID_IS_EMPTY_STRING, validation_result);
   ASSERT_EQ(0ul, invalid_index);
@@ -74,6 +84,12 @@ TEST(test_validate_topic_name, not_absolute) {
   ASSERT_EQ(RMW_TOPIC_INVALID_NOT_ABSOLUTE, validation_result);
   ASSERT_EQ(0ul, invalid_index);
 
+  // with invalid_index as NULL
+  ret = rmw_validate_topic_name("not/absolute", &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_TOPIC_INVALID_NOT_ABSOLUTE, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
   ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
 }
 
@@ -88,6 +104,12 @@ TEST(test_validate_topic_name, ends_with_forward_slash) {
   ASSERT_EQ(10ul, invalid_index);
 
   ret = rmw_validate_topic_name("/", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_TOPIC_INVALID_ENDS_WITH_FORWARD_SLASH, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
+  // with invalid_index as NULL
+  ret = rmw_validate_topic_name("/", &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   ASSERT_EQ(RMW_TOPIC_INVALID_ENDS_WITH_FORWARD_SLASH, validation_result);
   ASSERT_EQ(0ul, invalid_index);
@@ -120,6 +142,12 @@ TEST(test_validate_topic_name, unallowed_characters) {
   ASSERT_EQ(RMW_TOPIC_INVALID_CONTAINS_UNALLOWED_CHARACTERS, validation_result);
   ASSERT_EQ(5ul, invalid_index);
 
+  // with invalid_index as NULL
+  ret = rmw_validate_topic_name("/with spaces", &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_TOPIC_INVALID_CONTAINS_UNALLOWED_CHARACTERS, validation_result);
+  ASSERT_EQ(5ul, invalid_index);
+
   ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
 }
 
@@ -129,6 +157,12 @@ TEST(test_validate_topic_name, repeated_forward_slashes) {
   rmw_ret_t ret;
 
   ret = rmw_validate_topic_name("/repeated//slashes", &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_TOPIC_INVALID_CONTAINS_REPEATED_FORWARD_SLASH, validation_result);
+  ASSERT_EQ(10ul, invalid_index);
+
+  // with invalid_index as NULL
+  ret = rmw_validate_topic_name("/repeated//slashes", &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   ASSERT_EQ(RMW_TOPIC_INVALID_CONTAINS_REPEATED_FORWARD_SLASH, validation_result);
   ASSERT_EQ(10ul, invalid_index);
@@ -151,6 +185,12 @@ TEST(test_validate_topic_name, starts_with_number) {
   ASSERT_EQ(RMW_TOPIC_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER, validation_result);
   ASSERT_EQ(8ul, invalid_index);
 
+  // with invalid_index as NULL
+  ret = rmw_validate_topic_name("/starts/42with/number", &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_TOPIC_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER, validation_result);
+  ASSERT_EQ(8ul, invalid_index);
+
   ASSERT_NE((char *)NULL, rmw_topic_validation_result_string(validation_result));
 }
 
@@ -167,9 +207,23 @@ TEST(test_validate_topic_name, topic_too_long) {
   ASSERT_EQ(RMW_TOPIC_INVALID_NOT_ABSOLUTE, validation_result);
   ASSERT_EQ(0ul, invalid_index);
 
+  // with invalid_index as NULL
+  ret = rmw_validate_topic_name(
+    invalid_and_long_topic.c_str(), &validation_result, nullptr);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  ASSERT_EQ(RMW_TOPIC_INVALID_NOT_ABSOLUTE, validation_result);
+  ASSERT_EQ(0ul, invalid_index);
+
   std::string valid_but_long_topic = "/" + invalid_and_long_topic;
   ret = rmw_validate_topic_name(
     valid_but_long_topic.c_str(), &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_OK, ret);
+  EXPECT_EQ(RMW_TOPIC_INVALID_TOO_LONG, validation_result);
+  EXPECT_EQ(RMW_TOPIC_MAX_NAME_LENGTH - 1, invalid_index);
+
+  // with invalid_index as NULL
+  ret = rmw_validate_topic_name(
+    valid_but_long_topic.c_str(), &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   EXPECT_EQ(RMW_TOPIC_INVALID_TOO_LONG, validation_result);
   EXPECT_EQ(RMW_TOPIC_MAX_NAME_LENGTH - 1, invalid_index);


### PR DESCRIPTION
This is the first change (as it includes the actual storage for the namespace) in a series of several changes up and down the stack. The purpose of these pull requests are to add the notion of a namespace for each node. This namespace will later be used to expand relative topic names and remapping rules.

This pr builds on https://github.com/ros2/rmw/pull/93 and include the commits from there. It should be rebased after that is merged.

This particular pr is relatively simple as it only adds storage for the namespace and adds it to the API for `rmw_create_node()`, see https://github.com/ros2/rmw/commit/14cd7272427b528d5f5ce9e71ea21ab16a3767a2.

I'm going to leave this "in progress" until I get the other pull requests opened.