### PR TITLE
shuffle CMake code

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -1,19 +1,28 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(rmw C)
+project(rmw)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+endif()
 
 find_package(ament_cmake REQUIRED)
 
 include(cmake/configure_rmw_library.cmake)
 
 include_directories(include)
-add_library(${PROJECT_NAME} SHARED
+
+set(rmw_sources
   "src/allocators.c"
   "src/error_handling.c"
   "src/validate_node_name.c"
   "src/validate_topic_name.c"
   "src/sanity_checks.c")
-configure_rmw_library(${PROJECT_NAME})
+set_source_files_properties(
+  ${rmw_sources}
+  PROPERTIES LANGUAGE "C")
+add_library(${PROJECT_NAME} SHARED ${rmw_sources})
+configure_rmw_library(${PROJECT_NAME} LANGUAGE "C")
 
 ament_export_dependencies(rosidl_generator_c)
 ament_export_include_directories(include)

--- a/rmw/test/CMakeLists.txt
+++ b/rmw/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-enable_language(CXX)
-
 find_package(ament_cmake_gmock REQUIRED)
 
 ament_add_gmock(test_error_handling
@@ -9,12 +7,6 @@ ament_add_gmock(test_error_handling
 )
 if(TARGET test_error_handling)
   target_link_libraries(test_error_handling ${PROJECT_NAME})
-  if(UNIX AND NOT APPLE)
-    target_link_libraries(test_error_handling pthread)
-  endif()
-  if(NOT WIN32)
-    set_target_properties(test_error_handling PROPERTIES COMPILE_FLAGS "-std=c++14")
-  endif()
 endif()
 
 ament_add_gmock(test_isalnum_no_locale
@@ -24,12 +16,6 @@ ament_add_gmock(test_isalnum_no_locale
 )
 if(TARGET test_isalnum_no_locale)
   target_link_libraries(test_isalnum_no_locale ${PROJECT_NAME})
-  if(UNIX AND NOT APPLE)
-    target_link_libraries(test_isalnum_no_locale pthread)
-  endif()
-  if(NOT WIN32)
-    set_target_properties(test_isalnum_no_locale PROPERTIES COMPILE_FLAGS "-std=c++14")
-  endif()
 endif()
 
 ament_add_gmock(test_validate_topic_name
@@ -39,12 +25,6 @@ ament_add_gmock(test_validate_topic_name
 )
 if(TARGET test_validate_topic_name)
   target_link_libraries(test_validate_topic_name ${PROJECT_NAME})
-  if(UNIX AND NOT APPLE)
-    target_link_libraries(test_validate_topic_name pthread)
-  endif()
-  if(NOT WIN32)
-    set_target_properties(test_validate_topic_name PROPERTIES COMPILE_FLAGS "-std=c++14")
-  endif()
 endif()
 
 ament_add_gmock(test_validate_node_name
@@ -54,10 +34,4 @@ ament_add_gmock(test_validate_node_name
 )
 if(TARGET test_validate_node_name)
   target_link_libraries(test_validate_node_name ${PROJECT_NAME})
-  if(UNIX AND NOT APPLE)
-    target_link_libraries(test_validate_node_name pthread)
-  endif()
-  if(NOT WIN32)
-    set_target_properties(test_validate_node_name PROPERTIES COMPILE_FLAGS "-std=c++14")
-  endif()
 endif()


### PR DESCRIPTION
Several things are going on here:

* `enable_language` must be called in the root `CMakeLists.txt` (see [docs](https://cmake.org/cmake/help/v3.5/command/enable_language.html)). Due to the next bullet the call is just removed.
* Since both `C` and `CXX` are needed the `C` argument is removed from the `project()` call
* `gmock` is being build on demand and should use the same compiler flags as the actual test executables. Therefore the flag `-std=c++14` is being set globally.
* The `rmw` library should be build using the `C` compiler therefore explicitly setting the `LANGUAGE` property on the source files.
* The CMake macro `configure_rmw_library` can't assume that the library is being built by `CXX` and therefore needs to perform slightly different things in the `C` and `CXX` case. Since all other rmw libs are using a C++ compiler I used an optional argument which defaults to `CXX`. It is explicitly being set to `C` in this package only.
* Due to ament/gmock_vendor#2 the tests don't need to know about `pthread` anymore.

Depends on ament/gmock_vendor#2

CI builds:
* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2405)](http://ci.ros2.org/job/ci_linux/2405/)
* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1854)](http://ci.ros2.org/job/ci_osx/1854/)
* [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2522)](http://ci.ros2.org/job/ci_windows/2522/)