### PR TITLE
Control shared/static linking via BUILD_SHARED_LIBS and ament_cmake_ros

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 endif()
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 
 include(cmake/configure_rmw_library.cmake)
 
@@ -21,7 +21,7 @@ set(rmw_sources
 set_source_files_properties(
   ${rmw_sources}
   PROPERTIES LANGUAGE "C")
-add_library(${PROJECT_NAME} SHARED ${rmw_sources})
+add_library(${PROJECT_NAME} ${rmw_sources})
 configure_rmw_library(${PROJECT_NAME} LANGUAGE "C")
 
 ament_export_dependencies(rosidl_generator_c)

--- a/rmw/package.xml
+++ b/rmw/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <!-- This is required for the definition of the rosidl typesupport types -->
   <build_export_depend>rosidl_generator_c</build_export_depend>


### PR DESCRIPTION
Reverts #96 

@dirk-thomas I got the `rmw` tests passing locally with this PR, https://github.com/ament/gtest_vendor/pull/4 and https://github.com/ament/gmock_vendor/pull/3