### PR TITLE
use string_array_t from c_utilities package

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -8,6 +8,8 @@ endif()
 
 find_package(ament_cmake_ros REQUIRED)
 
+find_package(c_utilities REQUIRED)
+
 include(cmake/configure_rmw_library.cmake)
 
 include_directories(include)
@@ -23,8 +25,11 @@ set_source_files_properties(
   ${rmw_sources}
   PROPERTIES LANGUAGE "C")
 add_library(${PROJECT_NAME} ${rmw_sources})
+ament_target_dependencies(${PROJECT_NAME}
+  "c_utilities")
 configure_rmw_library(${PROJECT_NAME} LANGUAGE "C")
 
+ament_export_dependencies(c_utilities)
 ament_export_dependencies(rosidl_generator_c)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})

--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -29,8 +29,9 @@ ament_target_dependencies(${PROJECT_NAME}
   "c_utilities")
 configure_rmw_library(${PROJECT_NAME} LANGUAGE "C")
 
-ament_export_dependencies(c_utilities)
-ament_export_dependencies(rosidl_generator_c)
+ament_export_dependencies(
+  c_utilities
+  rosidl_generator_c)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 

--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -20,18 +20,19 @@ set(rmw_sources
   "src/validate_namespace.c"
   "src/validate_node_name.c"
   "src/validate_topic_name.c"
-  "src/sanity_checks.c")
-set_source_files_properties(
-  ${rmw_sources}
-  PROPERTIES LANGUAGE "C")
+  "src/sanity_checks.c"
+)
+set_source_files_properties(${rmw_sources} PROPERTIES LANGUAGE "C")
 add_library(${PROJECT_NAME} ${rmw_sources})
 ament_target_dependencies(${PROJECT_NAME}
-  "c_utilities")
+  "c_utilities"
+)
 configure_rmw_library(${PROJECT_NAME} LANGUAGE "C")
 
 ament_export_dependencies(
   c_utilities
-  rosidl_generator_c)
+  rosidl_generator_c
+)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -67,6 +67,8 @@ extern "C"
 #include <stddef.h>
 #include <stdint.h>
 
+#include "c_utilities/types.h"
+
 #include "rosidl_generator_c/message_type_support_struct.h"
 #include "rosidl_generator_c/service_type_support.h"
 
@@ -336,13 +338,7 @@ RMW_WARN_UNUSED
 rmw_ret_t
 rmw_get_node_names(
   const rmw_node_t * node,
-  rmw_string_array_t * node_names);
-
-RMW_PUBLIC
-RMW_WARN_UNUSED
-rmw_ret_t
-rmw_destroy_node_names(
-  rmw_string_array_t * node_names);
+  utilities_string_array_t * node_names);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/include/rmw/sanity_checks.h
+++ b/rmw/include/rmw/sanity_checks.h
@@ -20,6 +20,8 @@ extern "C"
 {
 #endif
 
+#include "c_utilities/types.h"
+
 #include "rmw/macros.h"
 #include "rmw/types.h"
 #include "rmw/visibility_control.h"
@@ -34,7 +36,7 @@ rmw_check_zero_rmw_topic_names_and_types(rmw_topic_names_and_types_t * tnat);
 RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_ret_t
-rmw_check_zero_rmw_string_array(rmw_string_array_t * array);
+rmw_check_zero_rmw_string_array(utilities_string_array_t * array);
 
 #if __cplusplus
 }

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -198,12 +198,6 @@ typedef struct RMW_PUBLIC_TYPE rmw_topic_names_and_types_t
   char ** type_names;
 } rmw_topic_names_and_types_t;
 
-typedef struct RMW_PUBLIC_TYPE rmw_string_array_t
-{
-  size_t size;
-  char ** data;
-} rmw_string_array_t;
-
 typedef struct RMW_PUBLIC_TYPE rmw_gid_t
 {
   const char * implementation_identifier;

--- a/rmw/package.xml
+++ b/rmw/package.xml
@@ -10,6 +10,9 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <build_depend>c_utilities</build_depend>
+  <build_export_depend>c_utilities</build_export_depend>
+
   <!-- This is required for the definition of the rosidl typesupport types -->
   <build_export_depend>rosidl_generator_c</build_export_depend>
 

--- a/rmw/src/sanity_checks.c
+++ b/rmw/src/sanity_checks.c
@@ -17,6 +17,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "c_utilities/types.h"
+
 #include "rmw/error_handling.h"
 #include "rmw/types.h"
 
@@ -45,7 +47,7 @@ rmw_check_zero_rmw_topic_names_and_types(
 
 rmw_ret_t
 rmw_check_zero_rmw_string_array(
-  rmw_string_array_t * array)
+  utilities_string_array_t * array)
 {
   if (!array) {
     RMW_SET_ERROR_MSG("array is null");


### PR DESCRIPTION
I remove the `rmw_string_array_t` in lieu of the implementation in `c_utilities`.
Connected PRs:

c_utilities: ros2/c_utilities#14
rmw_fastrtps: ros2/rmw_fastrtps#102
rmw_connext: ros2/rmw_connext#224
rmw_impl: ros2/rmw_implementation#20
rcl: ros2/rcl#118
rclcpp: ros2/rclcpp#320
rclpy: ros2/rclpy#75

