### PR TITLE
add avoid_ros_namespace_conventions qos option

### DIFF
--- a/rmw/include/rmw/error_handling.h
+++ b/rmw/include/rmw/error_handling.h
@@ -29,6 +29,10 @@ extern "C"
 
 typedef rcutils_error_state_t rmw_error_state_t;
 
+#define rmw_error_state_copy rcutils_error_state_copy
+
+#define rmw_error_state_fini rcutils_error_state_fini
+
 // TODO(wjwwood): replace this completely with rcutils_set_error_state()
 //                once the rmw APIs take an allocator that can be passed
 //                by the rmw implementations on to the error functions

--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -27,7 +27,8 @@ static const rmw_qos_profile_t rmw_qos_profile_sensor_data =
   RMW_QOS_POLICY_HISTORY_KEEP_LAST,
   5,
   RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
-  RMW_QOS_POLICY_DURABILITY_VOLATILE
+  RMW_QOS_POLICY_DURABILITY_VOLATILE,
+  false
 };
 
 static const rmw_qos_profile_t rmw_qos_profile_parameters =
@@ -35,7 +36,8 @@ static const rmw_qos_profile_t rmw_qos_profile_parameters =
   RMW_QOS_POLICY_HISTORY_KEEP_LAST,
   1000,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-  RMW_QOS_POLICY_DURABILITY_VOLATILE
+  RMW_QOS_POLICY_DURABILITY_VOLATILE,
+  false
 };
 
 static const rmw_qos_profile_t rmw_qos_profile_default =
@@ -43,7 +45,8 @@ static const rmw_qos_profile_t rmw_qos_profile_default =
   RMW_QOS_POLICY_HISTORY_KEEP_LAST,
   10,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-  RMW_QOS_POLICY_DURABILITY_VOLATILE
+  RMW_QOS_POLICY_DURABILITY_VOLATILE,
+  false
 };
 
 static const rmw_qos_profile_t rmw_qos_profile_services_default =
@@ -51,7 +54,8 @@ static const rmw_qos_profile_t rmw_qos_profile_services_default =
   RMW_QOS_POLICY_HISTORY_KEEP_LAST,
   10,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-  RMW_QOS_POLICY_DURABILITY_VOLATILE
+  RMW_QOS_POLICY_DURABILITY_VOLATILE,
+  false
 };
 
 static const rmw_qos_profile_t rmw_qos_profile_parameter_events =
@@ -59,7 +63,8 @@ static const rmw_qos_profile_t rmw_qos_profile_parameter_events =
   RMW_QOS_POLICY_HISTORY_KEEP_ALL,
   1000,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-  RMW_QOS_POLICY_DURABILITY_VOLATILE
+  RMW_QOS_POLICY_DURABILITY_VOLATILE,
+  false
 };
 
 static const rmw_qos_profile_t rmw_qos_profile_system_default =
@@ -67,7 +72,8 @@ static const rmw_qos_profile_t rmw_qos_profile_system_default =
   RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT,
   RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT,
   RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT
+  RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT,
+  false
 };
 
 #if __cplusplus

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -189,6 +189,17 @@ typedef struct RMW_PUBLIC_TYPE rmw_qos_profile_t
   size_t depth;
   enum rmw_qos_reliability_policy_t reliability;
   enum rmw_qos_durability_policy_t durability;
+  /// If true, any ROS specific namespacing conventions will be circumvented.
+  /**
+   * In the case of DDS and topics, for example, this means the typical
+   * ROS specific prefix of `rt` would not be applied as described here:
+   *
+   *   http://design.ros2.org/articles/topic_and_service_names.html#ros-specific-namespace-prefix
+   *
+   * This might be useful when trying to directly connect a native DDS topic
+   * with a ROS 2 topic.
+   */
+  bool avoid_ros_namespace_conventions;
 } rmw_qos_profile_t;
 
 typedef struct RMW_PUBLIC_TYPE rmw_topic_names_and_types_t


### PR DESCRIPTION
This adds the `avoid_ros_namespace_conventions` QoS option to the rmw qos policies structure. It is a `bool` and if it is `true` then the underlying rmw implementations must avoid using the ROS specific prefix as described here:

http://design.ros2.org/articles/topic_and_service_names.html#communicating-with-non-ros-topics

There are several more pull requests to come, including pr's to actually use this option in Fast-RTPS and Connext, as well as tests.

(also I had a local change that crept in there, but it should be fine, it's just propagating aliases to new `rcutils` error handling functions which are already in `rcutils` master).