### PR TITLE
Add C11 compiler flag

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project(rmw)
 
 if(NOT WIN32)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 endif()
 


### PR DESCRIPTION
This fixes a compiler error/warning with the Raspberry Pi cross compiler caused by declaring a variable in the following `for` loops:

https://github.com/ros2/rmw/blob/master/rmw/src/validate_node_name.c#L43
https://github.com/ros2/rmw/blob/master/rmw/src/validate_full_topic_name.c#L59
https://github.com/ros2/rmw/blob/master/rmw/src/validate_full_topic_name.c#L79

alternatively, this issue could be solved by just declaring the index variable outside the for loops.