### PR TITLE
Explicitly set C11 and C++14 via the CMake variables

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -2,8 +2,15 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rmw)
 
-set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 14)
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 find_package(ament_cmake_ros REQUIRED)
 

--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -2,9 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rmw)
 
-if(NOT WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-endif()
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(ament_cmake_ros REQUIRED)
 


### PR DESCRIPTION
This PR explicitly sets the version of the C standard to C11