### PR TITLE
contributes an out-of-the-box durability profile

### DIFF
--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -31,6 +31,15 @@ static const rmw_qos_profile_t rmw_qos_profile_sensor_data =
   false
 };
 
+static const rmw_qos_profile_t rmw_qos_profile_durable =
+{
+  RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+  2,
+  RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+  RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+  false
+};
+
 static const rmw_qos_profile_t rmw_qos_profile_parameters =
 {
   RMW_QOS_POLICY_HISTORY_KEEP_LAST,


### PR DESCRIPTION
Things like a map server benefit from a durable message (aka, send the last published map to each subscriber as they subscribe). We should have one of these in the default profile list, especially with talk of being able to select from canned QoS profiles using command line parameters.