### PR TITLE
add allocators to macros.hpp

### DIFF
--- a/rmw/include/rmw/impl/cpp/macros.hpp
+++ b/rmw/include/rmw/impl/cpp/macros.hpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <string>
 
+#include "rmw/allocators.h"
 #include "rmw/error_handling.h"
 #include "rmw/impl/config.h"  // For RMW_AVOID_MEMORY_ALLOCATION
 #include "rmw/impl/cpp/demangle.hpp"  // For demangle.


### PR DESCRIPTION
this adds the `#include rmw/allocators.h` to this `macros.hpp` which otherwise every user of this file has to include manually.