### PR TITLE
Snprintf round2

### DIFF
--- a/rmw/include/rmw/impl/cpp/macros.hpp
+++ b/rmw/include/rmw/impl/cpp/macros.hpp
@@ -19,7 +19,7 @@
 #include <sstream>
 #include <string>
 
-#include <rcutils/snprintf.h>
+#include "rcutils/snprintf.h"
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"

--- a/rmw/include/rmw/impl/cpp/macros.hpp
+++ b/rmw/include/rmw/impl/cpp/macros.hpp
@@ -19,6 +19,8 @@
 #include <sstream>
 #include <string>
 
+#include <rcutils/snprintf.h>
+
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"
 #include "rmw/impl/config.h"  // For RMW_AVOID_MEMORY_ALLOCATION
@@ -70,7 +72,7 @@
 #define RMW_CHECK_TYPE_IDENTIFIERS_MATCH(ElementName, ElementTypeID, ExpectedTypeID, OnFailure) { \
   if (ElementTypeID != ExpectedTypeID) { \
     char __msg[1024]; \
-    snprintf( \
+    rcutils_snprintf( \
       __msg, 1024, \
       #ElementName " implementation '%s'(%p) does not match rmw implementation '%s'(%p)", \
       ElementTypeID, reinterpret_cast<const void *>(ElementTypeID), \
@@ -82,14 +84,14 @@
 #else  // RMW_AVOID_MEMORY_ALLOCATION
 #define RMW_CHECK_TYPE_IDENTIFIERS_MATCH(ElementName, ElementTypeID, ExpectedTypeID, OnFailure) { \
   if (ElementTypeID != ExpectedTypeID) { \
-    size_t __bytes_that_would_have_been_written = snprintf( \
+    size_t __bytes_that_would_have_been_written = rcutils_snprintf( \
       NULL, 0, \
       #ElementName " implementation '%s'(%p) does not match rmw implementation '%s'(%p)", \
       ElementTypeID, reinterpret_cast<const void *>(ElementTypeID), \
       ExpectedTypeID, reinterpret_cast<const void *>(ExpectedTypeID)); \
     char * __msg = \
       reinterpret_cast<char *>(rmw_allocate(__bytes_that_would_have_been_written + 1)); \
-    snprintf( \
+    rcutils_snprintf( \
       __msg, __bytes_that_would_have_been_written + 1, \
       #ElementName " implementation '%s'(%p) does not match rmw implementation '%s'(%p)", \
       ElementTypeID, reinterpret_cast<const void *>(ElementTypeID), \


### PR DESCRIPTION
missed some snprintfs in https://github.com/ros2/rmw/pull/116

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2932)](http://ci.ros2.org/job/ci_linux/2932/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=399)](http://ci.ros2.org/job/ci_linux-aarch64/399/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2376)](http://ci.ros2.org/job/ci_osx/2376/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3057)](http://ci.ros2.org/job/ci_windows/3057/)

linter failure addressed in https://github.com/ros2/rmw/commit/8b113f5a7355a4c7ff1c14b6f23ad58228a3ddef