### PR TITLE
Make the TOPIC and NAMESPACE macros unsigned.

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -12,6 +12,10 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra)
+endif()
+
 find_package(ament_cmake_ros REQUIRED)
 
 find_package(rcutils REQUIRED)

--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake_ros REQUIRED)

--- a/rmw/include/rmw/validate_full_topic_name.h
+++ b/rmw/include/rmw/validate_full_topic_name.h
@@ -32,7 +32,7 @@ extern "C"
 #define RMW_TOPIC_INVALID_NAME_TOKEN_STARTS_WITH_NUMBER 6
 #define RMW_TOPIC_INVALID_TOO_LONG 7
 
-#define RMW_TOPIC_MAX_NAME_LENGTH 255 /* impl constraint */ - 8 /* reserved for prefixes */
+#define RMW_TOPIC_MAX_NAME_LENGTH 255U /* impl constraint */ - 8U /* reserved for prefixes */
 
 /// Determine if a given fully qualified topic name is valid.
 /** Validity of a FQN for topic is determined based on rules defined here:

--- a/rmw/include/rmw/validate_namespace.h
+++ b/rmw/include/rmw/validate_namespace.h
@@ -34,7 +34,7 @@ extern "C"
 #define RMW_NAMESPACE_INVALID_TOO_LONG 7
 
 // An additional 2 characters are reserved for the shortest possible topic, e.g. '/X'.
-#define RMW_NAMESPACE_MAX_LENGTH (RMW_TOPIC_MAX_NAME_LENGTH - 2)
+#define RMW_NAMESPACE_MAX_LENGTH (RMW_TOPIC_MAX_NAME_LENGTH - 2U)
 
 /// Determine if a given namespace is valid.
 /** Validity of a namespace is based on rules for a topic defined here:

--- a/rmw/src/allocators.c
+++ b/rmw/src/allocators.c
@@ -33,7 +33,7 @@ rmw_allocate(size_t size)
 void
 rmw_free(void * pointer)
 {
-  // Should have a corresponding overide with rmw_allocate
+  // Should have a corresponding override with rmw_allocate
   free(pointer);
 }
 

--- a/rmw/test/test_validate_node_name.cpp
+++ b/rmw/test/test_validate_node_name.cpp
@@ -153,14 +153,14 @@ TEST(test_validate_node_name, node_name_too_long) {
     valid_but_long_node_name.c_str(), &validation_result, &invalid_index);
   ASSERT_EQ(RMW_RET_OK, ret);
   EXPECT_EQ(RMW_NODE_NAME_INVALID_TOO_LONG, validation_result);
-  EXPECT_EQ(RMW_NODE_NAME_MAX_NAME_LENGTH - 1, invalid_index);
+  EXPECT_EQ(RMW_NODE_NAME_MAX_NAME_LENGTH - 1U, invalid_index);
 
   // with invalid_index as NULL
   ret = rmw_validate_node_name(
     valid_but_long_node_name.c_str(), &validation_result, nullptr);
   ASSERT_EQ(RMW_RET_OK, ret);
   EXPECT_EQ(RMW_NODE_NAME_INVALID_TOO_LONG, validation_result);
-  EXPECT_EQ(RMW_NODE_NAME_MAX_NAME_LENGTH - 1, invalid_index);
+  EXPECT_EQ(RMW_NODE_NAME_MAX_NAME_LENGTH - 1U, invalid_index);
 
   ASSERT_NE((char *)NULL, rmw_node_name_validation_result_string(validation_result));
 }


### PR DESCRIPTION
This is more correct; they can never be negative, as that
doesn't make any sense.  This also fixes some warnings on
mismatched types that get thrown up when adding -Wall -Wextra
to the flags, which this commit also does.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

connects to ros2/ros2#387

CI jobs are in the above issue