### PR TITLE
Fix clang warnings from pedantic.

### DIFF
--- a/rmw/src/names_and_types.c
+++ b/rmw/src/names_and_types.c
@@ -24,7 +24,7 @@ rmw_names_and_types_t
 rmw_get_zero_initialized_names_and_types(void)
 {
   static rmw_names_and_types_t zero = {
-    .names = {0},
+    .names = {0, NULL, {NULL, NULL, NULL, NULL, NULL}},
     .types = NULL,
   };
   zero.names = rcutils_get_zero_initialized_string_array();

--- a/rmw/src/node_security_options.c
+++ b/rmw/src/node_security_options.c
@@ -17,7 +17,7 @@
 rmw_node_security_options_t
 rmw_get_zero_initialized_node_security_options()
 {
-  static rmw_node_security_options_t null_security_options = {0};
+  static rmw_node_security_options_t null_security_options = {0, NULL};
   return null_security_options;
 }
 


### PR DESCRIPTION
I made a mistake with my last PR turning on pedantic, and
it turns out that clang is a little more picky.  Fix
that here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I only ran CI on the OSX build that was throwing warnings, and only up to rmw which now seems to be fixed:

http://ci.ros2.org/job/ci_osx/2416