### PR TITLE
remove unused domain_id field from rmw_node_t

### DIFF
--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -46,7 +46,6 @@ typedef struct RMW_PUBLIC_TYPE rmw_node_t
   void * data;
   const char * name;
   const char * namespace_;
-  const size_t domain_id;
 } rmw_node_t;
 
 typedef struct RMW_PUBLIC_TYPE rmw_publisher_t


### PR DESCRIPTION
Remove field which is not set by any of the rmw implementation.

An alternative would be to remove the `const` and update all rmw implementations to set the value.