### PR TITLE
rclpy gets the default rmw_implementation through rmw_implementation_…

### DIFF
--- a/rmw_implementation_cmake/cmake/get_default_rmw_implementation.cmake
+++ b/rmw_implementation_cmake/cmake/get_default_rmw_implementation.cmake
@@ -33,8 +33,6 @@ macro(get_default_rmw_implementation var)
     "$ENV{RMW_IMPLEMENTATION}" STREQUAL ""
   )
     # prefer FastRTPS, otherwise first in alphabetical order
-    # the same logic is implemented in
-    # rclpy.impl.rmw_implementation_tools.import_rmw_implementation()
     list(FIND _middleware_implementations "rmw_fastrtps_cpp" _index)
     if(NOT _index EQUAL -1)
       list(GET _middleware_implementations ${_index} _middleware_implementation)


### PR DESCRIPTION
…cmake now.

The logic has been consolidated in https://github.com/ros2/rclpy/pull/82 making this comment obsolete