### PR TITLE
optimize not to access uninitialized scalar variable

### DIFF
--- a/rmw/src/validate_namespace.c
+++ b/rmw/src/validate_namespace.c
@@ -79,7 +79,8 @@ rmw_validate_namespace(
           // explicitly not taking return value which is number of bytes written
           rcutils_snprintf(
             default_err_msg, sizeof(default_err_msg),
-            "rmw_validate_namespace(): unknown rmw_validate_full_topic_name() result");
+            "rmw_validate_namespace(): unknown rmw_validate_full_topic_name() result '%d'",
+            t_validation_result);
           RMW_SET_ERROR_MSG(default_err_msg);
         }
         return RMW_RET_ERROR;

--- a/rmw/src/validate_namespace.c
+++ b/rmw/src/validate_namespace.c
@@ -79,9 +79,7 @@ rmw_validate_namespace(
           // explicitly not taking return value which is number of bytes written
           rcutils_snprintf(
             default_err_msg, sizeof(default_err_msg),
-            "rmw_validate_namespace(): unknown rmw_validate_full_topic_name() result '%d'",
-            *validation_result
-          );
+            "rmw_validate_namespace(): unknown rmw_validate_full_topic_name() result");
           RMW_SET_ERROR_MSG(default_err_msg);
         }
         return RMW_RET_ERROR;


### PR DESCRIPTION
when the `validation_result` is not initialized and it's better not access
it to avoid unknown issue, like in [_rclpy.c](https://github.com/ros2/rclpy/blob/master/rclpy/src/rclpy/_rclpy.c#L414-L416), moreover, the error msg without 
that value is also  enough to reflect the fact.

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>