### PR TITLE
waitset -> wait_set

### DIFF
--- a/rmw/include/rmw/allocators.h
+++ b/rmw/include/rmw/allocators.h
@@ -80,12 +80,12 @@ void
 rmw_service_free(rmw_service_t * service);
 
 RMW_PUBLIC
-rmw_waitset_t *
-rmw_waitset_allocate(void);
+rmw_wait_set_t *
+rmw_wait_set_allocate(void);
 
 RMW_PUBLIC
 void
-rmw_waitset_free(rmw_waitset_t * waitset);
+rmw_wait_set_free(rmw_wait_set_t * wait_set);
 
 #if __cplusplus
 }

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -277,25 +277,25 @@ RMW_WARN_UNUSED
 rmw_ret_t
 rmw_trigger_guard_condition(const rmw_guard_condition_t * guard_condition);
 
-/// Create a waitset to store conditions that the middleware will block on.
+/// Create a wait_set to store conditions that the middleware will block on.
 /**
- * If `max_conditions` is `0`, the waitset can store an unbounded number of
+ * If `max_conditions` is `0`, the wait_set can store an unbounded number of
  * conditions to wait on.
  * If `max_conditions` is greater than `0`, the number of conditions that can
- * be attached to the waitset is bounded at `max_conditions`.
+ * be attached to the wait_set is bounded at `max_conditions`.
  * \param[in] max_conditions
- *   The maximum number of conditions that can be attached to the waitset.
- * \return A pointer to the created waitset, `NULL` if an error occurred.
+ *   The maximum number of conditions that can be attached to the wait_set.
+ * \return A pointer to the created wait_set, `NULL` if an error occurred.
  */
 RMW_PUBLIC
 RMW_WARN_UNUSED
-rmw_waitset_t *
-rmw_create_waitset(size_t max_conditions);
+rmw_wait_set_t *
+rmw_create_wait_set(size_t max_conditions);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_ret_t
-rmw_destroy_waitset(rmw_waitset_t * waitset);
+rmw_destroy_wait_set(rmw_wait_set_t * wait_set);
 
 /// Waits on sets of different waitable entities and returns when one is ready.
 /**
@@ -303,7 +303,7 @@ rmw_destroy_waitset(rmw_waitset_t * waitset);
  * the timeout is reached.
  * The arrays contain type-erased representations of waitable entities.
  * This function casts the pointers to middleware-specific conditions and adds
- * them to the waitset.
+ * them to the wait_set.
  *
  * The count variables in the arrays represents the number of valid pointers
  * in the array.
@@ -321,12 +321,12 @@ rmw_destroy_waitset(rmw_waitset_t * waitset);
  * \param guard_conditions Array of guard conditions to wait on
  * \param services Array of services to wait on
  * \param clients Array of clients to wait on
- * \param waitset Storage for the waitset
+ * \param wait_set Storage for the wait_set
  * \param wait_timeout
  *   If negative, block indefinitely or until a condition is ready.
  *   If zero, check only for immediately available conditions and don't block.
  *   Else, this represents the maximum time to wait for a response from the
- *   waitset.
+ *   wait_set.
  * \return `RMW_RET_OK` if success, or
  * \return `RMW_RET_ERROR` if error, or
  * \return `RMW_RET_TIMEOUT` if wait timed out.
@@ -339,7 +339,7 @@ rmw_wait(
   rmw_guard_conditions_t * guard_conditions,
   rmw_services_t * services,
   rmw_clients_t * clients,
-  rmw_waitset_t * waitset,
+  rmw_wait_set_t * wait_set,
   const rmw_time_t * wait_timeout);
 
 RMW_PUBLIC

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -277,15 +277,15 @@ RMW_WARN_UNUSED
 rmw_ret_t
 rmw_trigger_guard_condition(const rmw_guard_condition_t * guard_condition);
 
-/// Create a wait_set to store conditions that the middleware will block on.
+/// Create a wait set to store conditions that the middleware will block on.
 /**
- * If `max_conditions` is `0`, the wait_set can store an unbounded number of
+ * If `max_conditions` is `0`, the wait set can store an unbounded number of
  * conditions to wait on.
  * If `max_conditions` is greater than `0`, the number of conditions that can
- * be attached to the wait_set is bounded at `max_conditions`.
+ * be attached to the wait set is bounded at `max_conditions`.
  * \param[in] max_conditions
- *   The maximum number of conditions that can be attached to the wait_set.
- * \return A pointer to the created wait_set, `NULL` if an error occurred.
+ *   The maximum number of conditions that can be attached to the wait set.
+ * \return A pointer to the created wait set, `NULL` if an error occurred.
  */
 RMW_PUBLIC
 RMW_WARN_UNUSED
@@ -303,7 +303,7 @@ rmw_destroy_wait_set(rmw_wait_set_t * wait_set);
  * the timeout is reached.
  * The arrays contain type-erased representations of waitable entities.
  * This function casts the pointers to middleware-specific conditions and adds
- * them to the wait_set.
+ * them to the wait set.
  *
  * The count variables in the arrays represents the number of valid pointers
  * in the array.
@@ -321,12 +321,12 @@ rmw_destroy_wait_set(rmw_wait_set_t * wait_set);
  * \param guard_conditions Array of guard conditions to wait on
  * \param services Array of services to wait on
  * \param clients Array of clients to wait on
- * \param wait_set Storage for the wait_set
+ * \param wait_set Storage for the wait set
  * \param wait_timeout
  *   If negative, block indefinitely or until a condition is ready.
  *   If zero, check only for immediately available conditions and don't block.
  *   Else, this represents the maximum time to wait for a response from the
- *   wait_set.
+ *   wait set.
  * \return `RMW_RET_OK` if success, or
  * \return `RMW_RET_ERROR` if error, or
  * \return `RMW_RET_TIMEOUT` if wait timed out.

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -142,12 +142,12 @@ typedef struct RMW_PUBLIC_TYPE rmw_guard_conditions_t
   void ** guard_conditions;
 } rmw_guard_conditions_t;
 
-typedef struct RMW_PUBLIC_TYPE rmw_waitset_t
+typedef struct RMW_PUBLIC_TYPE rmw_wait_set_t
 {
   const char * implementation_identifier;
   rmw_guard_conditions_t * guard_conditions;
   void * data;
-} rmw_waitset_t;
+} rmw_wait_set_t;
 
 typedef struct RMW_PUBLIC_TYPE rmw_request_id_t
 {

--- a/rmw/src/allocators.c
+++ b/rmw/src/allocators.c
@@ -122,16 +122,16 @@ rmw_service_free(rmw_service_t * service)
   rmw_free(service);
 }
 
-rmw_waitset_t *
-rmw_waitset_allocate()
+rmw_wait_set_t *
+rmw_wait_set_allocate()
 {
   // Could be overridden with custom (maybe static) client struct allocator
-  return (rmw_waitset_t *)rmw_allocate(sizeof(rmw_waitset_t));
+  return (rmw_wait_set_t *)rmw_allocate(sizeof(rmw_wait_set_t));
 }
 
 void
-rmw_waitset_free(rmw_waitset_t * waitset)
+rmw_wait_set_free(rmw_wait_set_t * wait_set)
 {
-  // Should have matching overide with rmw_waitset_allocate
-  rmw_free(waitset);
+  // Should have matching overide with rmw_wait_set_allocate
+  rmw_free(wait_set);
 }


### PR DESCRIPTION
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3593)](http://ci.ros2.org/job/ci_linux/3593/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=786)](http://ci.ros2.org/job/ci_linux-aarch64/786/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2933)](http://ci.ros2.org/job/ci_osx/2933/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3685)](http://ci.ros2.org/job/ci_windows/3685/)

Linux after linter fixes:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3595)](http://ci.ros2.org/job/ci_linux/3595/)