### PR TITLE
Clarify that NULL blocks forever in rmw_wait

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -323,7 +323,7 @@ rmw_destroy_wait_set(rmw_wait_set_t * wait_set);
  * \param clients Array of clients to wait on
  * \param wait_set Storage for the wait set
  * \param wait_timeout
- *   If negative, block indefinitely or until a condition is ready.
+ *   If NULL, block until a condition is ready
  *   If zero, check only for immediately available conditions and don't block.
  *   Else, this represents the maximum time to wait for a response from the
  *   wait set.

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -323,7 +323,7 @@ rmw_destroy_wait_set(rmw_wait_set_t * wait_set);
  * \param clients Array of clients to wait on
  * \param wait_set Storage for the wait set
  * \param wait_timeout
- *   If NULL, block until a condition is ready
+ *   If NULL, block until a condition is ready.
  *   If zero, check only for immediately available conditions and don't block.
  *   Else, this represents the maximum time to wait for a response from the
  *   wait set.


### PR DESCRIPTION
The documentation says `rmw_wait()` blocks forever if the timeout is negative, but the timeout cannot be negative because `rmw_time_t` uses unsigned types.

```C
typedef struct RMW_PUBLIC_TYPE rmw_time_t
{
  uint64_t sec;
  uint64_t nsec;
} rmw_time_t;
```

If ros2/rcutils#79 leads to `rclutils_time_point_value_t` using a signed type then it may make sense to propagate signed-ness down to `rmw`, but either way this documentation should still say it blocks when the time pointer passed in is NULL.

CI Linux, only testing `rmw` for any linter tests since this is a documentation change only
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3896)](http://ci.ros2.org/job/ci_linux/3896/)