### PR TITLE
Add validation functions accepting string length

### DIFF
--- a/rmw/include/rmw/validate_full_topic_name.h
+++ b/rmw/include/rmw/validate_full_topic_name.h
@@ -89,6 +89,22 @@ rmw_validate_full_topic_name(
   int * validation_result,
   size_t * invalid_index);
 
+/// Deterimine if a given topic name is valid.
+/**
+ * This is an overload with an extra parameter for the length of topic_name.
+ * \param[in] topic_name_length The number of characters in topic_name.
+ *
+ * \sa rmw_validate_full_topic_name(const char *, int *, size_t *)
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_validate_full_topic_name_with_size(
+  const char * topic_name,
+  size_t topic_name_length,
+  int * validation_result,
+  size_t * invalid_index);
+
 /// Return a validation result description, or NULL if unknown or RMW_TOPIC_VALID.
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/include/rmw/validate_namespace.h
+++ b/rmw/include/rmw/validate_namespace.h
@@ -95,6 +95,22 @@ rmw_validate_namespace(
   int * validation_result,
   size_t * invalid_index);
 
+/// Deterimine if a given namespace is valid.
+/**
+ * This is an overload with an extra parameter for the length of namespace_.
+ * \param[in] namespace_length The number of characters in namespace_.
+ *
+ * \sa rmw_validate_namespace(const char *, int *, size_t *)
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_validate_namespace_with_size(
+  const char * namespace_,
+  size_t namespace_length,
+  int * validation_result,
+  size_t * invalid_index);
+
 /// Return a validation result description, or NULL if unknown or RMW_NAMESPACE_VALID.
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/include/rmw/validate_node_name.h
+++ b/rmw/include/rmw/validate_node_name.h
@@ -83,6 +83,22 @@ rmw_validate_node_name(
   int * validation_result,
   size_t * invalid_index);
 
+/// Deterimine if a given node name is valid.
+/**
+ * This is an overload with an extra parameter for the length of node_name.
+ * \param[in] node_name_length The number of characters in node_name.
+ *
+ * \sa rmw_validate_node_name(const char *, int *, size_t *)
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_validate_node_name_with_size(
+  const char * node_name,
+  size_t node_name_length,
+  int * validation_result,
+  size_t * invalid_index);
+
 /// Return a validation result description, or NULL if unknown or RMW_NODE_NAME_VALID.
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/src/validate_full_topic_name.c
+++ b/rmw/src/validate_full_topic_name.c
@@ -28,10 +28,23 @@ rmw_validate_full_topic_name(
   if (!topic_name) {
     return RMW_RET_INVALID_ARGUMENT;
   }
+  return rmw_validate_full_topic_name_with_size(
+    topic_name, strlen(topic_name), validation_result, invalid_index);
+}
+
+rmw_ret_t
+rmw_validate_full_topic_name_with_size(
+  const char * topic_name,
+  size_t topic_name_length,
+  int * validation_result,
+  size_t * invalid_index)
+{
+  if (!topic_name) {
+    return RMW_RET_INVALID_ARGUMENT;
+  }
   if (!validation_result) {
     return RMW_RET_INVALID_ARGUMENT;
   }
-  size_t topic_name_length = strlen(topic_name);
   if (topic_name_length == 0) {
     *validation_result = RMW_TOPIC_INVALID_IS_EMPTY_STRING;
     if (invalid_index) {

--- a/rmw/src/validate_namespace.c
+++ b/rmw/src/validate_namespace.c
@@ -32,11 +32,24 @@ rmw_validate_namespace(
   if (!namespace_) {
     return RMW_RET_INVALID_ARGUMENT;
   }
+  return rmw_validate_namespace_with_size(
+    namespace_, strlen(namespace_), validation_result, invalid_index);
+}
+
+rmw_ret_t
+rmw_validate_namespace_with_size(
+  const char * namespace_,
+  size_t namespace_length,
+  int * validation_result,
+  size_t * invalid_index)
+{
+  if (!namespace_) {
+    return RMW_RET_INVALID_ARGUMENT;
+  }
   if (!validation_result) {
     return RMW_RET_INVALID_ARGUMENT;
   }
 
-  size_t namespace_length = strlen(namespace_);
   // Special case for root namepsace
   if (namespace_length == 1 && namespace_[0] == '/') {
     // Ok to return here, it is valid and will not exceed RMW_NAMESPACE_MAX_LENGTH.

--- a/rmw/src/validate_node_name.c
+++ b/rmw/src/validate_node_name.c
@@ -28,10 +28,23 @@ rmw_validate_node_name(
   if (!node_name) {
     return RMW_RET_INVALID_ARGUMENT;
   }
+  return rmw_validate_node_name_with_size(
+    node_name, strlen(node_name), validation_result, invalid_index);
+}
+
+rmw_ret_t
+rmw_validate_node_name_with_size(
+  const char * node_name,
+  size_t node_name_length,
+  int * validation_result,
+  size_t * invalid_index)
+{
+  if (!node_name) {
+    return RMW_RET_INVALID_ARGUMENT;
+  }
   if (!validation_result) {
     return RMW_RET_INVALID_ARGUMENT;
   }
-  size_t node_name_length = strlen(node_name);
   if (node_name_length == 0) {
     *validation_result = RMW_NODE_NAME_INVALID_IS_EMPTY_STRING;
     if (invalid_index) {


### PR DESCRIPTION
This PR splits the validation functions to allow passing the length of the string as a parameter. Adding these methods allows ros2/rcl#217 to avoid copying some strings while parsing remap rules.

* `rmw_validate_full_topic_name_with_size()`
* `rmw_validate_namespace_with_size()`
* `rmw_validate_node_name_with_size()`

CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4070)](http://ci.ros2.org/job/ci_linux/4070/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1173)](http://ci.ros2.org/job/ci_linux-aarch64/1173/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3377)](http://ci.ros2.org/job/ci_osx/3377/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4142)](http://ci.ros2.org/job/ci_windows/4142/)