### PR TITLE
get encoding identifier

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -104,9 +104,10 @@ rmw_get_implementation_identifier(void);
 /**
  * Return the format in which binary data is serialized.
  * One middleware can only have one encoding.
- * In contrast to the implementation identifier, the serialization format can be
- * equal between multiple RMW implementations. This means, that the same binary
- * messages can be deserialized by RMW implementations with the same format.
+ * In contrast to the implementation identifier, the serialization format can be equal between
+ * multiple RMW implementations.
+ * This means, that the same binary messages can be deserialized by RMW implementations with the
+ * same format.
  * \sa rmw_serialize
  * \sa rmw_deserialize
  * \return serialization format

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -100,6 +100,22 @@ RMW_WARN_UNUSED
 const char *
 rmw_get_implementation_identifier(void);
 
+/// Get the unique encoding identifier for this middleware.
+/**
+ * The unique encoding identifier states in which encoding the
+ * serialized data has to be interpreted.
+ * One middleware can only have one encoding.
+ * In contrast to the implementation identifier, the encoding identifier can be
+ * equal between multiple RMW implementations. This means, that the same binary
+ * messages can be deserialized by RMW implementations with the same encoding ID.
+ * See also rmw_serialize, rmw_deserialize
+ * \return encoding identifier
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+const char *
+rmw_get_encoding_identifier(void);
+
 RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_ret_t

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -108,7 +108,8 @@ rmw_get_implementation_identifier(void);
  * In contrast to the implementation identifier, the encoding identifier can be
  * equal between multiple RMW implementations. This means, that the same binary
  * messages can be deserialized by RMW implementations with the same encoding ID.
- * See also rmw_serialize, rmw_deserialize
+ * \sa rmw_serialize
+ * \sa rmw_deserialize
  * \return encoding identifier
  */
 RMW_PUBLIC

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -100,22 +100,21 @@ RMW_WARN_UNUSED
 const char *
 rmw_get_implementation_identifier(void);
 
-/// Get the unique encoding identifier for this middleware.
+/// Get the unique serialization format for this middleware.
 /**
- * The unique encoding identifier states in which encoding the
- * serialized data has to be interpreted.
+ * Return the format in which binary data is serialized.
  * One middleware can only have one encoding.
- * In contrast to the implementation identifier, the encoding identifier can be
+ * In contrast to the implementation identifier, the serialization format can be
  * equal between multiple RMW implementations. This means, that the same binary
- * messages can be deserialized by RMW implementations with the same encoding ID.
+ * messages can be deserialized by RMW implementations with the same format.
  * \sa rmw_serialize
  * \sa rmw_deserialize
- * \return encoding identifier
+ * \return serialization format
  */
 RMW_PUBLIC
 RMW_WARN_UNUSED
 const char *
-rmw_get_encoding_identifier(void);
+rmw_get_serialization_format(void);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED


### PR DESCRIPTION
With respect to the upcoming development for rosbags, we need to extract the encoding format for each RMW middleware. 

The encoding identifier differs from the implementation identifier in the sense that each implementation has to be uniquely identified, but multiple RMW can use the same encoding (e.g. cdr for DDS implementations).