### PR TITLE
Add semicolons to RCLCPP and RCUTILS macros.

### DIFF
--- a/rmw/src/names_and_types.c
+++ b/rmw/src/names_and_types.c
@@ -73,7 +73,7 @@ rmw_names_and_types_init(
   if (!names_and_types->types) {
     rcutils_ret = rcutils_string_array_fini(&names_and_types->names);
     if (rcutils_ret != RCUTILS_RET_OK) {
-      RCUTILS_LOG_ERROR("error while reporting error: %s", rcutils_get_error_string_safe())
+      RCUTILS_LOG_ERROR("error while reporting error: %s", rcutils_get_error_string_safe());
     }
     RMW_SET_ERROR_MSG_ALLOC("failed to allocate memory for types", *allocator)
     return RMW_RET_BAD_ALLOC;


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Connects to https://github.com/ros2/rcutils/issues/113