### PR TITLE
RMW configuration from XML only

### DIFF
--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -28,6 +28,7 @@ static const rmw_qos_profile_t rmw_qos_profile_sensor_data =
   5,
   RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
   RMW_QOS_POLICY_DURABILITY_VOLATILE,
+  false,
   false
 };
 
@@ -37,6 +38,7 @@ static const rmw_qos_profile_t rmw_qos_profile_parameters =
   1000,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
   RMW_QOS_POLICY_DURABILITY_VOLATILE,
+  false,
   false
 };
 
@@ -46,6 +48,7 @@ static const rmw_qos_profile_t rmw_qos_profile_default =
   10,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
   RMW_QOS_POLICY_DURABILITY_VOLATILE,
+  false,
   false
 };
 
@@ -55,6 +58,7 @@ static const rmw_qos_profile_t rmw_qos_profile_services_default =
   10,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
   RMW_QOS_POLICY_DURABILITY_VOLATILE,
+  false,
   false
 };
 
@@ -64,6 +68,7 @@ static const rmw_qos_profile_t rmw_qos_profile_parameter_events =
   1000,
   RMW_QOS_POLICY_RELIABILITY_RELIABLE,
   RMW_QOS_POLICY_DURABILITY_VOLATILE,
+  false,
   false
 };
 
@@ -73,7 +78,18 @@ static const rmw_qos_profile_t rmw_qos_profile_system_default =
   RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT,
   RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT,
   RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT,
+  false,
   false
+};
+
+static const rmw_qos_profile_t rmw_qos_profile_user_xml =
+{
+  RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT,
+  10,
+  RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT,
+  RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT,
+  false,
+  true
 };
 
 #ifdef __cplusplus

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -215,6 +215,9 @@ typedef struct RMW_PUBLIC_TYPE rmw_qos_profile_t
    * with a ROS 2 topic.
    */
   bool avoid_ros_namespace_conventions;
+  /// If true, all the configuration must be set in the XML config files and the configuration
+  /// set in code won't be applied.
+  bool config_only_from_xml;  
 } rmw_qos_profile_t;
 
 typedef struct RMW_PUBLIC_TYPE rmw_gid_t


### PR DESCRIPTION
We have implemented a new feature to apply the RMW configuration only from XML files, avoiding the current configuration set by code. To do that we have added a new boolean value to the `rmw_qos_profile_t` struct.

Connects to ros2/ros2#589