### PR TITLE
Methods to retrieve matched counts on publisher and subscriber

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -196,12 +196,13 @@ rmw_publish(const rmw_publisher_t * publisher, const void * ros_message);
  * \param publisher the publisher object to inspect
  * \param subscription_count the number of subscriptions matched
  * \return `RMW_RET_OK` if successful, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if either argument is null, or
  * \return `RMW_RET_ERROR` if an unexpected error occurs.
  */
 RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_ret_t
-rmw_count_matched_subscriptions(
+rmw_publisher_count_matched_subscriptions(
   const rmw_publisher_t * publisher,
   size_t * subscription_count);
 
@@ -292,12 +293,13 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription);
  * \param subscription the publisher object to inspect
  * \param publisher_count the number of subscriptions matched
  * \return `RMW_RET_OK` if successful, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if either argument is null, or
  * \return `RMW_RET_ERROR` if an unexpected error occurs.
  */
 RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_ret_t
-rmw_count_matched_publishers(
+rmw_subscription_count_matched_publishers(
   const rmw_subscription_t * subscription,
   size_t * publisher_count);
 

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -188,6 +188,23 @@ RMW_WARN_UNUSED
 rmw_ret_t
 rmw_publish(const rmw_publisher_t * publisher, const void * ros_message);
 
+/// Retrieve the number of matched subscriptions to a publisher
+/**
+ * Query the underlying middleware to determine how many subscriptions are
+ * matched to a given publisher.
+ *
+ * \param publisher the publisher object to inspect
+ * \param subscription_count the number of subscriptions matched
+ * \return `RMW_RET_OK` if successful, or
+ * \return `RMW_RET_ERROR` if an unexpected error occurs.
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_count_matched_subscriptions(
+  const rmw_publisher_t * publisher,
+  size_t * subscription_count);
+
 /// Publish an already serialized message.
 /**
  * The publisher must already be registered with the correct message type
@@ -266,6 +283,23 @@ RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_ret_t
 rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription);
+
+/// Retrieve the number of matched publishers to a subscription
+/**
+ * Query the underlying middleware to determine how many publishers are
+ * matched to a given subscription.
+ *
+ * \param subscription the publisher object to inspect
+ * \param publisher_count the number of subscriptions matched
+ * \return `RMW_RET_OK` if successful, or
+ * \return `RMW_RET_ERROR` if an unexpected error occurs.
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_count_matched_publishers(
+  const rmw_subscription_t * subscription,
+  size_t * publisher_count);
 
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -290,8 +290,8 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription);
  * Query the underlying middleware to determine how many publishers are
  * matched to a given subscription.
  *
- * \param subscription the publisher object to inspect
- * \param publisher_count the number of subscriptions matched
+ * \param subscription the subscription object to inspect
+ * \param publisher_count the number of publishers matched
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if either argument is null, or
  * \return `RMW_RET_ERROR` if an unexpected error occurs.

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -188,13 +188,13 @@ RMW_WARN_UNUSED
 rmw_ret_t
 rmw_publish(const rmw_publisher_t * publisher, const void * ros_message);
 
-/// Retrieve the number of matched subscriptions to a publisher
+/// Retrieve the number of matched subscriptions to a publisher.
 /**
  * Query the underlying middleware to determine how many subscriptions are
  * matched to a given publisher.
  *
- * \param publisher the publisher object to inspect
- * \param subscription_count the number of subscriptions matched
+ * \param[in] publisher the publisher object to inspect
+ * \param[out] subscription_count the number of subscriptions matched
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if either argument is null, or
  * \return `RMW_RET_ERROR` if an unexpected error occurs.
@@ -285,13 +285,13 @@ RMW_WARN_UNUSED
 rmw_ret_t
 rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription);
 
-/// Retrieve the number of matched publishers to a subscription
+/// Retrieve the number of matched publishers to a subscription.
 /**
  * Query the underlying middleware to determine how many publishers are
  * matched to a given subscription.
  *
- * \param subscription the subscription object to inspect
- * \param publisher_count the number of publishers matched
+ * \param[in] subscription the subscription object to inspect
+ * \param[out] publisher_count the number of publishers matched
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if either argument is null, or
  * \return `RMW_RET_ERROR` if an unexpected error occurs.


### PR DESCRIPTION
This provides an API for retrieving the number of matched publishers to a subscription and vice-versa.  It is a method to be used with forthcoming additions in creating a port of `SubscriberStatusCallback` (from ROS 1, see: https://docs.ros.org/api/roscpp/html/namespaceros.html#ac61b99a2913cd421fb915395a67e71a1) for ROS2.

This is different from the existing graph methods, as it should interact directly with a  publisher or subscription to retrieve the matched count.

Requires changes in:

- [x] rmw_implementation https://github.com/ros2/rmw_implementation/pull/48
- [x] rcl https://github.com/ros2/rcl/pull/326
- [x] rmw_fastrtps https://github.com/ros2/rmw_fastrtps/pull/234
- [x] rmw_opensplice ros2/rmw_opensplice#248
- [x] rmw_connext ros2/rmw_connext#310