### PR TITLE
Add function for getting clients by node

### DIFF
--- a/rmw/include/rmw/get_node_info_and_types.h
+++ b/rmw/include/rmw/get_node_info_and_types.h
@@ -131,6 +131,41 @@ rmw_get_service_names_and_types_by_node(
   const char * node_namespace,
   rmw_names_and_types_t * service_names_and_types);
 
+/// Return a list of service client topic names and their types.
+/**
+ * This function returns a list of service client topic names and their types.
+ *
+ * The node parameter must not be `NULL`, and must point to a valid node.
+ *
+ * The topic_names_and_types parameter must be allocated and zero initialized.
+ * The topic_names_and_types is the output for this function, and contains
+ * allocated memory.
+ * Therefore, it should be passed to rmw_names_and_types_fini() when
+ * it is no longer needed.
+ * Failing to do so will result in leaked memory.
+ *
+ * \param[in] node the handle to the node being used to query the ROS graph
+ * \param[in] allocator allocator to be used when allocating space for strings
+ * \param[in] node_name the name of the node to get information for
+ * \param[in] node_namespace the namespace of the node to get information for
+ * \param[out] topic_names_and_types list of topic names and their types the
+ *   node_name has created a service client for
+ * \return `RMW_RET_OK` if the query was successful, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if the node is invalid, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if any arguments are invalid, or
+ * \return `RMW_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RMW_RET_ERROR` if an unspecified error occurs.
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_get_client_names_and_types_by_node(
+  const rmw_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * node_name,
+  const char * node_namespace,
+  rmw_names_and_types_t * service_names_and_types);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This enables us to distinguish between service clients and service servers when querying the ROS graph for services.

In particular, this will help resolve https://github.com/ros2/sros2/issues/94.