### PR TITLE
add option to filter available RMW implementations

### DIFF
--- a/rmw_implementation_cmake/cmake/get_available_rmw_implementations.cmake
+++ b/rmw_implementation_cmake/cmake/get_available_rmw_implementations.cmake
@@ -54,7 +54,7 @@ function(get_available_rmw_implementations var)
       set(middleware_implementations ${filtered})
     endforeach()
     message(STATUS
-      "Override available RMW implementations: ${middleware_implementations}")
+      "Filtered available RMW implementations: ${middleware_implementations}")
   endif()
 
   set(${var} ${middleware_implementations} PARENT_SCOPE)

--- a/rmw_implementation_cmake/cmake/get_available_rmw_implementations.cmake
+++ b/rmw_implementation_cmake/cmake/get_available_rmw_implementations.cmake
@@ -15,6 +15,12 @@
 #
 # Get the package names of the available ROS middleware implemenations.
 #
+# The result can be overridden by setting either a CMake or environment
+# variable named ``RMW_IMPLEMENTATIONS``.
+# The variable can contain RMW implementation names separated by the platform
+# specific path separator.
+# Including an unavailable RMW implementation results in a fatal error message.
+#
 # :param var: the output variable name containing the package names
 # :type var: list of strings
 #
@@ -24,5 +30,32 @@ function(get_available_rmw_implementations var)
     list(REMOVE_ITEM middleware_implementations "rmw_implementation")
     list(SORT middleware_implementations)
   endif()
+
+  # use explicitly provided list if provided
+  # option()
+  if(NOT "$ENV{RMW_IMPLEMENTATIONS}" STREQUAL "")
+    string(REPLACE ":" ";" RMW_IMPLEMENTATIONS "$ENV{RMW_IMPLEMENTATIONS}")
+  endif()
+  if(NOT "${RMW_IMPLEMENTATIONS}" STREQUAL "")
+    # check if given RMW implementations are available
+    foreach(rmw_implementation ${RMW_IMPLEMENTATIONS})
+      if(NOT "${rmw_implementation}" IN_LIST middleware_implementations)
+        message(FATAL_ERROR
+          "The RMW implementation '${rmw_implementation}' specified in "
+          "'RMW_IMPLEMENTATIONS' is not available ("
+          "${middleware_implementations})")
+      endif()
+    endforeach()
+    set(filtered)
+    foreach(rmw_implementation ${middleware_implementations})
+      if("${rmw_implementation}" IN_LIST RMW_IMPLEMENTATIONS)
+        list(APPEND filtered "${rmw_implementation}")
+      endif()
+      set(middleware_implementations ${filtered})
+    endforeach()
+    message(STATUS
+      "Override available RMW implementations: ${middleware_implementations}")
+  endif()
+
   set(${var} ${middleware_implementations} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
This allows to e.g. only test with a subset of RMW implementations in an overlay workspace - even if the underlay workspace contains more RMW implementations.