### PR TITLE
Add tests for untested public functionality

### DIFF
--- a/rmw/test/CMakeLists.txt
+++ b/rmw/test/CMakeLists.txt
@@ -65,15 +65,6 @@ if(TARGET test_names_and_types)
   target_link_libraries(test_names_and_types ${PROJECT_NAME})
 endif()
 
-ament_add_gmock(test_node_security_options
-  test_node_security_options.cpp
-  # Append the directory of librmw so it is found at test time.
-  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
-)
-if(TARGET test_node_security_options)
-  target_link_libraries(test_node_security_options ${PROJECT_NAME})
-endif()
-
 ament_add_gmock(test_publisher_options
   test_publisher_options.cpp
   # Append the directory of librmw so it is found at test time.
@@ -90,6 +81,15 @@ ament_add_gmock(test_sanity_checks
 )
 if(TARGET test_sanity_checks)
   target_link_libraries(test_sanity_checks ${PROJECT_NAME})
+endif()
+
+ament_add_gmock(test_security_options
+  test_security_options.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_security_options)
+  target_link_libraries(test_security_options ${PROJECT_NAME})
 endif()
 
 ament_add_gmock(test_serialized_message

--- a/rmw/test/CMakeLists.txt
+++ b/rmw/test/CMakeLists.txt
@@ -1,6 +1,52 @@
 find_package(ament_cmake_gmock REQUIRED)
 find_package(osrf_testing_tools_cpp REQUIRED)
 
+
+ament_add_gmock(test_allocators
+  test_allocators.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_allocators)
+  target_link_libraries(test_allocators ${PROJECT_NAME})
+endif()
+
+ament_add_gmock(test_convert_rcutils_ret_to_rmw_ret
+  test_convert_rcutils_ret_to_rmw_ret.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_convert_rcutils_ret_to_rmw_ret)
+  target_link_libraries(test_convert_rcutils_ret_to_rmw_ret ${PROJECT_NAME})
+endif()
+
+ament_add_gmock(test_event
+  test_event.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_event)
+  target_link_libraries(test_event ${PROJECT_NAME})
+endif()
+
+ament_add_gmock(test_init_options
+  test_init_options.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_init_options)
+  target_link_libraries(test_init_options ${PROJECT_NAME})
+endif()
+
+ament_add_gmock(test_init
+  test_init.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_init)
+  target_link_libraries(test_init ${PROJECT_NAME})
+endif()
+
 ament_add_gmock(test_message_sequence
   test_message_sequence.cpp
   # Append the directory of librmw so it is found at test time.
@@ -10,6 +56,42 @@ if(TARGET test_message_sequence)
   target_link_libraries(test_message_sequence ${PROJECT_NAME})
 endif()
 
+ament_add_gmock(test_names_and_types
+  test_names_and_types.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_names_and_types)
+  target_link_libraries(test_names_and_types ${PROJECT_NAME})
+endif()
+
+ament_add_gmock(test_node_security_options
+  test_node_security_options.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_node_security_options)
+  target_link_libraries(test_node_security_options ${PROJECT_NAME})
+endif()
+
+ament_add_gmock(test_publisher_options
+  test_publisher_options.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_publisher_options)
+  target_link_libraries(test_publisher_options ${PROJECT_NAME})
+endif()
+
+ament_add_gmock(test_sanity_checks
+  test_sanity_checks.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_sanity_checks)
+  target_link_libraries(test_sanity_checks ${PROJECT_NAME})
+endif()
+
 ament_add_gmock(test_serialized_message
   test_serialized_message.cpp
   # Append the directory of librmw so it is found at test time.
@@ -17,6 +99,15 @@ ament_add_gmock(test_serialized_message
 )
 if(TARGET test_serialized_message)
   target_link_libraries(test_serialized_message ${PROJECT_NAME})
+endif()
+
+ament_add_gmock(test_subscription_options
+  test_subscription_options.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_subscription_options)
+  target_link_libraries(test_subscription_options ${PROJECT_NAME})
 endif()
 
 ament_add_gmock(test_validate_full_topic_name

--- a/rmw/test/test_allocators.cpp
+++ b/rmw/test/test_allocators.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Open Source Robotics Foundation, Inc.
+// Copyright 2020 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
+
 #include "gmock/gmock.h"
 #include "rmw/allocators.h"
 

--- a/rmw/test/test_allocators.cpp
+++ b/rmw/test/test_allocators.cpp
@@ -1,0 +1,64 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "gmock/gmock.h"
+#include "rmw/allocators.h"
+
+TEST(test_rmw_allocators, rmw_allocate_free) {
+  void * ptr = rmw_allocate(100u);
+  EXPECT_NE(ptr, nullptr);
+  rmw_free(ptr);
+}
+
+TEST(test_rmw_allocators, rmw_node_allocate_free) {
+  rmw_node_t * node = rmw_node_allocate();
+  EXPECT_NE(node, nullptr);
+  rmw_node_free(node);
+}
+
+TEST(test_rmw_allocators, rmw_publisher_allocate_free) {
+  rmw_publisher_t * publisher = rmw_publisher_allocate();
+  EXPECT_NE(publisher, nullptr);
+  rmw_publisher_free(publisher);
+}
+
+TEST(test_rmw_allocators, rmw_subscription_allocate_free) {
+  rmw_subscription_t * subscriber = rmw_subscription_allocate();
+  EXPECT_NE(subscriber, nullptr);
+  rmw_subscription_free(subscriber);
+}
+
+TEST(test_rmw_allocators, rmw_guard_condition_allocate_free) {
+  rmw_guard_condition_t * guard_condition = rmw_guard_condition_allocate();
+  EXPECT_NE(guard_condition, nullptr);
+  rmw_guard_condition_free(guard_condition);
+}
+
+TEST(test_rmw_allocators, rmw_client_allocate_free) {
+  rmw_client_t * client = rmw_client_allocate();
+  EXPECT_NE(client, nullptr);
+  rmw_client_free(client);
+}
+
+TEST(test_rmw_allocators, rmw_service_allocate_free) {
+  rmw_service_t * service = rmw_service_allocate();
+  EXPECT_NE(service, nullptr);
+  rmw_service_free(service);
+}
+
+TEST(test_rmw_allocators, rmw_wait_set_allocate_free) {
+  rmw_wait_set_t * wait_set = rmw_wait_set_allocate();
+  EXPECT_NE(wait_set, nullptr);
+  rmw_wait_set_free(wait_set);
+}

--- a/rmw/test/test_convert_rcutils_ret_to_rmw_ret.cpp
+++ b/rmw/test/test_convert_rcutils_ret_to_rmw_ret.cpp
@@ -1,0 +1,32 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "rmw/convert_rcutils_ret_to_rmw_ret.h"
+
+TEST(test_convert_rcutils_ret_to_rmw_ret, convert_rcutils_ret)
+{
+  // Types that currently have a 1-to-1 correspondance. Add below as mappings are added
+  EXPECT_EQ(rmw_convert_rcutils_ret_to_rmw_ret(RCUTILS_RET_OK), RMW_RET_OK);
+  EXPECT_EQ(
+    rmw_convert_rcutils_ret_to_rmw_ret(RCUTILS_RET_INVALID_ARGUMENT), RMW_RET_INVALID_ARGUMENT);
+  EXPECT_EQ(rmw_convert_rcutils_ret_to_rmw_ret(RCUTILS_RET_BAD_ALLOC), RMW_RET_BAD_ALLOC);
+  EXPECT_EQ(rmw_convert_rcutils_ret_to_rmw_ret(RCUTILS_RET_ERROR), RMW_RET_ERROR);
+
+  // Some of the types that don't have mappings in rmw
+  EXPECT_EQ(rmw_convert_rcutils_ret_to_rmw_ret(RCUTILS_RET_WARN), RMW_RET_ERROR);
+  EXPECT_EQ(rmw_convert_rcutils_ret_to_rmw_ret(RCUTILS_RET_NOT_ENOUGH_SPACE), RMW_RET_ERROR);
+  EXPECT_EQ(rmw_convert_rcutils_ret_to_rmw_ret(RCUTILS_RET_NOT_INITIALIZED), RMW_RET_ERROR);
+  EXPECT_EQ(rmw_convert_rcutils_ret_to_rmw_ret(RCUTILS_RET_NOT_FOUND), RMW_RET_ERROR);
+}

--- a/rmw/test/test_event.cpp
+++ b/rmw/test/test_event.cpp
@@ -1,0 +1,40 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "rmw/event.h"
+
+TEST(rmw_event, get_zero_initialized_event)
+{
+  const rmw_event_t actual = rmw_get_zero_initialized_event();
+  EXPECT_EQ(nullptr, actual.implementation_identifier);
+  EXPECT_EQ(nullptr, actual.data);
+  EXPECT_EQ(RMW_EVENT_INVALID, actual.event_type);
+}
+
+TEST(rmw_event, event_fini)
+{
+  EXPECT_EQ(rmw_event_fini(nullptr), RMW_RET_INVALID_ARGUMENT);
+
+  rmw_event_t event;
+  event.implementation_identifier = "identifier";
+  char data[20] = "datadatadata";
+  event.data = &data[0];
+  event.event_type = RMW_EVENT_LIVELINESS_CHANGED;
+
+  EXPECT_EQ(rmw_event_fini(&event), RMW_RET_OK);
+  EXPECT_EQ(nullptr, event.implementation_identifier);
+  EXPECT_EQ(nullptr, event.data);
+  EXPECT_EQ(RMW_EVENT_INVALID, event.event_type);
+}

--- a/rmw/test/test_init.cpp
+++ b/rmw/test/test_init.cpp
@@ -1,0 +1,23 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "rmw/init.h"
+
+TEST(rmw_init_options, get_zero_initialized_init_options)
+{
+  const rmw_context_t context = rmw_get_zero_initialized_context();
+  EXPECT_EQ(context.instance_id, 0u);
+  EXPECT_EQ(context.impl, nullptr);
+}

--- a/rmw/test/test_init_options.cpp
+++ b/rmw/test/test_init_options.cpp
@@ -1,0 +1,24 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "rmw/init_options.h"
+
+TEST(rmw_init_options, get_zero_initialized_init_options)
+{
+  const rmw_init_options_t options = rmw_get_zero_initialized_init_options();
+  EXPECT_EQ(options.instance_id, 0u);
+  EXPECT_EQ(options.implementation_identifier, nullptr);
+  EXPECT_EQ(options.impl, nullptr);
+}

--- a/rmw/test/test_loaned_message_sequence.cpp
+++ b/rmw/test/test_loaned_message_sequence.cpp
@@ -1,0 +1,24 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "rmw/loaned_message_sequence.h"
+
+TEST(rmw_loaned_message_sequence, get_zero_init)
+{
+  rmw_loaned_message_sequence_t sequence = rmw_get_zero_initialized_loaned_message_sequence();
+  EXPECT_EQ(sequence.message_sequence, nullptr);
+  EXPECT_EQ(sequence.size, 0u);
+  EXPECT_EQ(sequence.capacity, 0u);
+}

--- a/rmw/test/test_names_and_types.cpp
+++ b/rmw/test/test_names_and_types.cpp
@@ -1,0 +1,139 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+
+#include "rcutils/error_handling.h"
+#include "rmw/error_handling.h"
+#include "rmw/names_and_types.h"
+
+namespace
+{
+void *
+bad_zero_allocator(size_t number, size_t size, void * state)
+{
+  RCUTILS_UNUSED(number);
+  RCUTILS_UNUSED(size);
+  RCUTILS_UNUSED(state);
+  return nullptr;
+}
+}  // namespace
+
+
+TEST(rmw_names_and_types, get_zero_init)
+{
+  rmw_names_and_types_t names_and_types = rmw_get_zero_initialized_names_and_types();
+  EXPECT_EQ(names_and_types.names.size, 0u);
+  EXPECT_EQ(names_and_types.names.data, nullptr);
+
+  EXPECT_EQ(names_and_types.names.allocator.allocate, nullptr);
+  EXPECT_EQ(names_and_types.names.allocator.deallocate, nullptr);
+  EXPECT_EQ(names_and_types.names.allocator.reallocate, nullptr);
+  EXPECT_EQ(names_and_types.names.allocator.zero_allocate, nullptr);
+  EXPECT_EQ(names_and_types.names.allocator.state, nullptr);
+  EXPECT_EQ(names_and_types.types, nullptr);
+}
+
+TEST(rmw_names_and_types, rmw_names_and_types_check_zero) {
+  EXPECT_EQ(rmw_names_and_types_check_zero(nullptr), RMW_RET_INVALID_ARGUMENT);
+  rmw_names_and_types_t names_and_types;
+  rmw_reset_error();
+
+  // Size is not 0
+  names_and_types.names.size = 1;
+  EXPECT_EQ(rmw_names_and_types_check_zero(&names_and_types), RMW_RET_INVALID_ARGUMENT);
+  names_and_types.names.size = 0;
+  rmw_reset_error();
+
+  // data is not null
+  char s[20] = "I'm a string!";
+  char * data[2] = {&s[0], &s[1]};
+  names_and_types.names.data = &data[0];
+  EXPECT_EQ(rmw_names_and_types_check_zero(&names_and_types), RMW_RET_INVALID_ARGUMENT);
+  names_and_types.names.data = nullptr;
+  rcutils_reset_error();
+
+  // types is not null
+  rcutils_string_array_t string_array;
+  names_and_types.types = &string_array;
+  EXPECT_EQ(rmw_names_and_types_check_zero(&names_and_types), RMW_RET_INVALID_ARGUMENT);
+  names_and_types.types = nullptr;
+  rmw_reset_error();
+
+  // OK
+  names_and_types = rmw_get_zero_initialized_names_and_types();
+  EXPECT_EQ(rmw_names_and_types_check_zero(&names_and_types), RMW_RET_OK);
+}
+
+TEST(rmw_names_and_types, rmw_names_and_types_init) {
+  rmw_names_and_types_t names_and_types;
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  size_t size = 100;
+
+  // allocator is null
+  rmw_ret_t result = rmw_names_and_types_init(&names_and_types, size, nullptr);
+  EXPECT_EQ(result, RMW_RET_INVALID_ARGUMENT);
+  rmw_reset_error();
+
+  // names_and_types is null
+  result = rmw_names_and_types_init(nullptr, size, &allocator);
+  EXPECT_EQ(result, RMW_RET_INVALID_ARGUMENT);
+  rmw_reset_error();
+
+  // allocator fails to allocate memory to names
+  allocator.zero_allocate = &bad_zero_allocator;
+  result = rmw_names_and_types_init(&names_and_types, size, &allocator);
+  EXPECT_EQ(result, RMW_RET_BAD_ALLOC);
+  allocator = rcutils_get_default_allocator();
+  rmw_reset_error();
+
+  // Fails to deallocate after failing to zero allocate types
+  allocator.zero_allocate = &bad_zero_allocator;
+  allocator.deallocate = nullptr;
+  result = rmw_names_and_types_init(&names_and_types, size, &allocator);
+  EXPECT_EQ(result, RMW_RET_BAD_ALLOC);
+  allocator = rcutils_get_default_allocator();
+  rmw_reset_error();
+
+  result = rmw_names_and_types_init(&names_and_types, size, &allocator);
+  EXPECT_EQ(result, RMW_RET_OK);
+}
+
+TEST(rmw_names_and_types, rmw_names_and_types_fini) {
+  rmw_names_and_types_t names_and_types = rmw_get_zero_initialized_names_and_types();
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  size_t size = 100;
+
+  rmw_ret_t result = rmw_names_and_types_init(&names_and_types, size, &allocator);
+  EXPECT_EQ(result, RMW_RET_OK);
+
+  // names_and_types is nullptr
+  EXPECT_EQ(rmw_names_and_types_fini(nullptr), RMW_RET_INVALID_ARGUMENT);
+  rmw_reset_error();
+
+  // Ok
+  EXPECT_EQ(rmw_names_and_types_fini(&names_and_types), RMW_RET_OK);
+
+  // Size != 0 and types is null
+  auto types_ptr = names_and_types.types;
+  names_and_types.types = nullptr;
+  EXPECT_EQ(rmw_names_and_types_fini(&names_and_types), RMW_RET_INVALID_ARGUMENT);
+  rmw_reset_error();
+  names_and_types.types = types_ptr;
+
+  // bad allocator, rcutils fails to finalize string array
+  names_and_types.names.allocator.deallocate = nullptr;
+  EXPECT_EQ(rmw_names_and_types_fini(&names_and_types), RMW_RET_INVALID_ARGUMENT);
+  rmw_reset_error();
+}

--- a/rmw/test/test_node_security_options.cpp
+++ b/rmw/test/test_node_security_options.cpp
@@ -1,0 +1,30 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "rmw/node_security_options.h"
+
+TEST(rmw_node_security_options, get_zero_init)
+{
+  rmw_node_security_options_t options = rmw_get_zero_initialized_node_security_options();
+  EXPECT_EQ(options.enforce_security, RMW_SECURITY_ENFORCEMENT_PERMISSIVE);
+  EXPECT_EQ(options.security_root_path, nullptr);
+}
+
+TEST(rmw_node_security_options, get_default_init)
+{
+  rmw_node_security_options_t options = rmw_get_default_node_security_options();
+  EXPECT_EQ(options.enforce_security, RMW_SECURITY_ENFORCEMENT_PERMISSIVE);
+  EXPECT_EQ(options.security_root_path, nullptr);
+}

--- a/rmw/test/test_publisher_options.cpp
+++ b/rmw/test/test_publisher_options.cpp
@@ -1,0 +1,22 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "rmw/publisher_options.h"
+
+TEST(rmw_publisher_options, get_default_publisher_options)
+{
+  rmw_publisher_options_t options = rmw_get_default_publisher_options();
+  EXPECT_EQ(options.rmw_specific_publisher_payload, nullptr);
+}

--- a/rmw/test/test_sanity_checks.cpp
+++ b/rmw/test/test_sanity_checks.cpp
@@ -1,0 +1,42 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+
+#include "rmw/error_handling.h"
+#include "rmw/sanity_checks.h"
+
+TEST(rmw_sanity_checks, check_zero_rmw_string_array)
+{
+  EXPECT_EQ(rmw_check_zero_rmw_string_array(nullptr), RMW_RET_ERROR);
+  rmw_reset_error();
+
+  // size is not 0
+  rcutils_string_array_t string_array;
+  string_array.size = 1;
+  EXPECT_EQ(rmw_check_zero_rmw_string_array(&string_array), RMW_RET_ERROR);
+  string_array.size = 0;
+  rmw_reset_error();
+
+  // data is not nullptr
+  char s[20] = "hello there";
+  char * data[2] = {&s[0], &s[1]};
+  string_array.data = &data[0];
+  EXPECT_EQ(rmw_check_zero_rmw_string_array(&string_array), RMW_RET_ERROR);
+  rmw_reset_error();
+
+  // Ok
+  string_array = rcutils_get_zero_initialized_string_array();
+  EXPECT_EQ(rmw_check_zero_rmw_string_array(&string_array), RMW_RET_OK);
+}

--- a/rmw/test/test_security_options.cpp
+++ b/rmw/test/test_security_options.cpp
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 #include "gmock/gmock.h"
-#include "rmw/node_security_options.h"
+#include "rmw/security_options.h"
 
-TEST(rmw_node_security_options, get_zero_init)
+TEST(rmw_security_options, get_zero_init)
 {
-  rmw_node_security_options_t options = rmw_get_zero_initialized_node_security_options();
+  rmw_security_options_t options = rmw_get_zero_initialized_security_options();
   EXPECT_EQ(options.enforce_security, RMW_SECURITY_ENFORCEMENT_PERMISSIVE);
   EXPECT_EQ(options.security_root_path, nullptr);
 }
 
-TEST(rmw_node_security_options, get_default_init)
+TEST(rmw_security_options, get_default_init)
 {
-  rmw_node_security_options_t options = rmw_get_default_node_security_options();
+  rmw_security_options_t options = rmw_get_default_security_options();
   EXPECT_EQ(options.enforce_security, RMW_SECURITY_ENFORCEMENT_PERMISSIVE);
   EXPECT_EQ(options.security_root_path, nullptr);
 }

--- a/rmw/test/test_subscription_options.cpp
+++ b/rmw/test/test_subscription_options.cpp
@@ -1,0 +1,23 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+#include "rmw/subscription_options.h"
+
+TEST(rmw_subscription_options, get_default_subscription_options)
+{
+  rmw_subscription_options_t options = rmw_get_default_subscription_options();
+  EXPECT_EQ(options.rmw_specific_subscription_payload, nullptr);
+  EXPECT_EQ(options.ignore_local_publications, false);
+}

--- a/rmw/test/test_topic_endpoint_info.cpp
+++ b/rmw/test/test_topic_endpoint_info.cpp
@@ -16,6 +16,7 @@
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcutils/allocator.h"
 
+#include "rmw/error_handling.h"
 #include "rmw/topic_endpoint_info.h"
 #include "rmw/types.h"
 
@@ -33,11 +34,17 @@ TEST(test_topic_endpoint_info, set_topic_type) {
   char * val = get_mallocd_string("test_topic_type");
   rmw_ret_t ret = rmw_topic_endpoint_info_set_topic_type(&topic_endpoint_info, val, nullptr);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << "Expected invalid argument for null allocator";
+  rmw_reset_error();
+
   ret = rmw_topic_endpoint_info_set_topic_type(&topic_endpoint_info, nullptr, &allocator);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << "Expected invalid argument for null topic_type";
+  rmw_reset_error();
+
   ret = rmw_topic_endpoint_info_set_topic_type(nullptr, val, &allocator);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) <<
     "Expected invalid argument for null topic_endpoint_info";
+  rmw_reset_error();
+
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
     allocator.deallocate(const_cast<char *>(topic_endpoint_info.topic_type), allocator.state);
@@ -57,11 +64,17 @@ TEST(test_topic_endpoint_info, set_node_name) {
   char * val = get_mallocd_string("test_node_name");
   rmw_ret_t ret = rmw_topic_endpoint_info_set_node_name(&topic_endpoint_info, val, nullptr);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << "Expected invalid argument for null allocator";
+  rmw_reset_error();
+
   ret = rmw_topic_endpoint_info_set_node_name(&topic_endpoint_info, nullptr, &allocator);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << "Expected invalid argument for null node_name";
+  rmw_reset_error();
+
   ret = rmw_topic_endpoint_info_set_node_name(nullptr, val, &allocator);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) <<
     "Expected invalid argument for null topic_endpoint_info";
+  rmw_reset_error();
+
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
     allocator.deallocate(const_cast<char *>(topic_endpoint_info.node_name), allocator.state);
@@ -80,11 +93,17 @@ TEST(test_topic_endpoint_info, set_node_namespace) {
   char * val = get_mallocd_string("test_node_namespace");
   rmw_ret_t ret = rmw_topic_endpoint_info_set_node_namespace(&topic_endpoint_info, val, nullptr);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << "Expected invalid argument for null allocator";
+  rmw_reset_error();
+
   ret = rmw_topic_endpoint_info_set_node_namespace(&topic_endpoint_info, nullptr, &allocator);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << "Expected invalid argument for null node_namespace";
+  rmw_reset_error();
+
   ret = rmw_topic_endpoint_info_set_node_namespace(nullptr, val, &allocator);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) <<
     "Expected invalid argument for null topic_endpoint_info";
+  rmw_reset_error();
+
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
     allocator.deallocate(const_cast<char *>(topic_endpoint_info.node_namespace), allocator.state);
@@ -106,9 +125,13 @@ TEST(test_topic_endpoint_info, set_gid) {
   rmw_ret_t ret = rmw_topic_endpoint_info_set_gid(nullptr, gid, RMW_GID_STORAGE_SIZE);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) <<
     "Expected invalid argument for null topic_endpoint_info";
+  rmw_reset_error();
+
   ret = rmw_topic_endpoint_info_set_gid(&topic_endpoint_info, gid, RMW_GID_STORAGE_SIZE + 1);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) <<
     "Expected invalid argument for size greater than RMW_GID_STORAGE_SIZE";
+  rmw_reset_error();
+
   ret = rmw_topic_endpoint_info_set_gid(&topic_endpoint_info, gid, RMW_GID_STORAGE_SIZE);
   EXPECT_EQ(ret, RMW_RET_OK) << "Expected OK for valid arguments";
   for (uint8_t i = 0; i < RMW_GID_STORAGE_SIZE; i++) {
@@ -132,8 +155,12 @@ TEST(test_topic_endpoint_info, set_qos_profile) {
   rmw_ret_t ret = rmw_topic_endpoint_info_set_qos_profile(nullptr, &qos_profile);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) <<
     "Expected invalid argument for null topic_endpoint_info";
+  rmw_reset_error();
+
   ret = rmw_topic_endpoint_info_set_qos_profile(&topic_endpoint_info, nullptr);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << "Expected invalid argument for null qos_profile";
+  rmw_reset_error();
+
   ret = rmw_topic_endpoint_info_set_qos_profile(&topic_endpoint_info, &qos_profile);
   EXPECT_EQ(ret, RMW_RET_OK) << "Expected OK for valid arguments";
 
@@ -215,6 +242,9 @@ TEST(test_topic_endpoint_info, fini) {
   }
   ret = rmw_topic_endpoint_info_set_endpoint_type(&topic_endpoint_info, RMW_ENDPOINT_PUBLISHER);
   EXPECT_EQ(ret, RMW_RET_OK) << "Expected OK for valid rmw_endpoint_type_t arguments";
+  ret = rmw_topic_endpoint_info_set_endpoint_type(nullptr, RMW_ENDPOINT_PUBLISHER);
+  EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << "Expected invalid argument for null topic endpoint";
+  rmw_reset_error();
   ret = rmw_topic_endpoint_info_set_gid(&topic_endpoint_info, gid, RMW_GID_STORAGE_SIZE);
   EXPECT_EQ(ret, RMW_RET_OK) << "Expected OK for valid gid arguments";
   ret = rmw_topic_endpoint_info_set_node_namespace(&topic_endpoint_info, "namespace", &allocator);
@@ -225,9 +255,11 @@ TEST(test_topic_endpoint_info, fini) {
   EXPECT_EQ(ret, RMW_RET_OK) << "Expected OK for valid topic_type arguments";
   ret = rmw_topic_endpoint_info_fini(&topic_endpoint_info, nullptr);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << "Expected invalid argument for null allocator";
+  rmw_reset_error();
   ret = rmw_topic_endpoint_info_fini(nullptr, &allocator);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) <<
     "Expected invalid argument for null topic_endpoint_info";
+  rmw_reset_error();
 
   ret = rmw_topic_endpoint_info_fini(&topic_endpoint_info, &allocator);
   // Verify that the values inside the struct are zero-ed out and finished.

--- a/rmw/test/test_topic_endpoint_info_array.cpp
+++ b/rmw/test/test_topic_endpoint_info_array.cpp
@@ -20,6 +20,17 @@
 #include "rmw/topic_endpoint_info_array.h"
 #include "rmw/types.h"
 
+namespace
+{
+void *
+bad_allocate(size_t size, void * state)
+{
+  RCUTILS_UNUSED(size);
+  RCUTILS_UNUSED(state);
+  return nullptr;
+}
+}  // namespace
+
 TEST(test_topic_endpoint_info_array, zero_initialize) {
   rmw_topic_endpoint_info_array_t arr = rmw_get_zero_initialized_topic_endpoint_info_array();
   EXPECT_EQ(arr.size, 0u);
@@ -56,11 +67,21 @@ TEST(test_topic_endpoint_info_array, check_init_with_size) {
     rmw_topic_endpoint_info_array_init_with_size(
       nullptr, 1,
       &allocator), RMW_RET_INVALID_ARGUMENT);
-  rmw_reset_error();
   EXPECT_FALSE(arr.info_array);
+  rmw_reset_error();
+
   rmw_ret_t ret = rmw_topic_endpoint_info_array_init_with_size(&arr, 5, &allocator);
   EXPECT_EQ(ret, RMW_RET_OK);
   EXPECT_TRUE(arr.info_array);
+
+  rcutils_allocator_t bad_allocator = rcutils_get_default_allocator();
+  rmw_topic_endpoint_info_array_t bad_arr = rmw_get_zero_initialized_topic_endpoint_info_array();
+  bad_allocator.allocate = &bad_allocate;
+  EXPECT_EQ(
+    rmw_topic_endpoint_info_array_init_with_size(
+      &bad_arr, 1,
+      &bad_allocator), RMW_RET_BAD_ALLOC);
+  rmw_reset_error();
 }
 
 TEST(test_topic_endpoint_info_array, check_fini) {
@@ -72,4 +93,9 @@ TEST(test_topic_endpoint_info_array, check_fini) {
   ret = rmw_topic_endpoint_info_array_fini(&arr, &allocator);
   EXPECT_EQ(ret, RMW_RET_OK);
   EXPECT_FALSE(arr.info_array);
+
+  EXPECT_EQ(rmw_topic_endpoint_info_array_fini(&arr, nullptr), RMW_RET_INVALID_ARGUMENT);
+  rmw_reset_error();
+  EXPECT_EQ(rmw_topic_endpoint_info_array_fini(nullptr, &allocator), RMW_RET_INVALID_ARGUMENT);
+  rmw_reset_error();
 }

--- a/rmw/test/test_validate_full_topic_name.cpp
+++ b/rmw/test/test_validate_full_topic_name.cpp
@@ -16,6 +16,7 @@
 
 #include "gmock/gmock.h"
 
+#include "rmw/error_handling.h"
 #include "rmw/validate_full_topic_name.h"
 
 TEST(test_validate_topic_name, invalid_parameters) {
@@ -25,6 +26,17 @@ TEST(test_validate_topic_name, invalid_parameters) {
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
   ret = rmw_validate_full_topic_name("test", nullptr, &invalid_index);
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+
+  // name is null pointer,
+  ret = rmw_validate_full_topic_name_with_size(nullptr, 0u, &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+  rmw_reset_error();
+
+  // Invalid validation result
+  ASSERT_STREQ(
+    "unknown result code for rwm topic name validation",
+    rmw_full_topic_name_validation_result_string(-1));
+  rmw_reset_error();
 }
 
 TEST(test_validate_topic_name, valid_topic) {
@@ -90,7 +102,9 @@ TEST(test_validate_topic_name, not_absolute) {
   ASSERT_EQ(RMW_TOPIC_INVALID_NOT_ABSOLUTE, validation_result);
   ASSERT_EQ(0ul, invalid_index);
 
-  ASSERT_NE((char *)nullptr, rmw_full_topic_name_validation_result_string(validation_result));
+  ASSERT_NE(
+    (char *)nullptr,
+    rmw_full_topic_name_validation_result_string(validation_result));
 }
 
 TEST(test_validate_topic_name, ends_with_forward_slash) {

--- a/rmw/test/test_validate_namespace.cpp
+++ b/rmw/test/test_validate_namespace.cpp
@@ -16,6 +16,7 @@
 
 #include "gmock/gmock.h"
 
+#include "rmw/error_handling.h"
 #include "rmw/validate_namespace.h"
 
 TEST(test_validate_namespace, invalid_parameters) {
@@ -25,6 +26,17 @@ TEST(test_validate_namespace, invalid_parameters) {
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
   ret = rmw_validate_namespace("/test", nullptr, &invalid_index);
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+
+  // name is null pointer,
+  ret = rmw_validate_namespace_with_size(nullptr, 0u, &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+  rmw_reset_error();
+
+  // Invalid validation result
+  ASSERT_STREQ(
+    "unknown result code for rmw namespace validation",
+    rmw_namespace_validation_result_string(-1));
+  rmw_reset_error();
 }
 
 TEST(test_validate_namespace, valid_namespace) {

--- a/rmw/test/test_validate_node_name.cpp
+++ b/rmw/test/test_validate_node_name.cpp
@@ -16,6 +16,7 @@
 
 #include "gmock/gmock.h"
 
+#include "rmw/error_handling.h"
 #include "rmw/validate_node_name.h"
 
 TEST(test_validate_node_name, invalid_parameters) {
@@ -25,6 +26,17 @@ TEST(test_validate_node_name, invalid_parameters) {
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
   ret = rmw_validate_node_name("test", nullptr, &invalid_index);
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+
+  // name is null pointer,
+  ret = rmw_validate_node_name_with_size(nullptr, 0u, &validation_result, &invalid_index);
+  ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+  rmw_reset_error();
+
+  // Invalid validation result
+  ASSERT_STREQ(
+    "unknown result code for rmw node name validation",
+    rmw_node_name_validation_result_string(-1));
+  rmw_reset_error();
 }
 
 TEST(test_validate_node_name, valid_node_name) {


### PR DESCRIPTION
This PR adds a bunch of simple tests for currently untested public API functionality. Gives a quick boost to coverage!

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9756)](http://ci.ros2.org/job/ci_linux/9756/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5379)](http://ci.ros2.org/job/ci_linux-aarch64/5379/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7928)](http://ci.ros2.org/job/ci_osx/7928/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9625)](http://ci.ros2.org/job/ci_windows/9625/)
* Coverage [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux_coverage&build=58)](https://ci.ros2.org/job/ci_linux_coverage/58/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>