### PR TITLE
Quality declarations for rmw and rmw_implementation_cmake

### DIFF
--- a/rmw/QUALITY_DECLARATION.md
+++ b/rmw/QUALITY_DECLARATION.md
@@ -68,7 +68,7 @@ There is documentation for all of the public API, and new additions to the publi
 
 ### License [3.iii]
 
-The license for `rmw` is Apache 2.0, and a summary is in each source file, the type is declared in the `package.xml` manifest file, and a full copy of the license is in the `LICENSE` file.
+The license for `rmw_implementation_cmake` is Apache 2.0, and a summary is in each source file, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the [LICENSE](../LICENSE) file.
 
 There is an automated test which runs a linter that ensures each file has a license statement.
 
@@ -79,6 +79,10 @@ Most recent test results can be found [here](http://build.ros2.org/view/Epr/job/
 The copyright holders each provide a statement of copyright in each source code file in `rmw`.
 
 There is an automated test which runs a linter that ensures each file has at least one copyright statement.
+
+The results of those tests are available [here](http://build.ros2.org/view/Epr/job/Epr__rmw__ubuntu_bionic_amd64/lastBuild/testReport/rmw/copyright/).
+
+Results of the copyright test can be found [here](http://build.ros2.org/view/Epr/job/Epr__rmw__ubuntu_bionic_amd64/lastBuild/testReport/rmw_implementation_cmake/copyright/).
 
 ## Testing [4]
 
@@ -104,15 +108,7 @@ The tests aim to cover both typical usage and corner cases, but are quantified b
 
 `rmw` uses and passes all the standard linters and static analysis tools for a C++ package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
 
-### Performance [5]
-
-TODO document performance tests
-
-`rmw` follows the recommendations for performance testing of C++ code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements), and opts to do performance analysis on each release rather than each change.
-
-### Linters and Static Analysis [4.v]
-
-`rmw` uses and passes all the standard linters and static analysis tools for a C++ package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+Results of linter tests can be found [here](http://build.ros2.org/view/Epr/job/Epr__rmw__ubuntu_bionic_amd64/lastBuild/testReport/rmw/).
 
 ## Dependencies [5]
 

--- a/rmw/QUALITY_DECLARATION.md
+++ b/rmw/QUALITY_DECLARATION.md
@@ -40,11 +40,11 @@ This package requires that all changes occur through a pull request.
 
 ### Contributor Origin [2.ii]
 
- This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
 
 ### Peer Review Policy [2.iii]
 
- Following the recommended guidelines for ROS Core packages, all pull requests must have at least 1 peer review.
+Following the recommended guidelines for ROS Core packages, all pull requests must have at least 1 peer review.
 
 ### Continuous Integration [2.iv]
 

--- a/rmw/QUALITY_DECLARATION.md
+++ b/rmw/QUALITY_DECLARATION.md
@@ -1,0 +1,144 @@
+This document is a declaration of software quality for the `rmw` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmw` Quality Declaration
+
+The package `rmw` claims to be in the **Quality Level 4** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmw` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmw` is not yet at a stable version, i.e. `>= 1.0.0`.
+
+### Public API Declaration [1.iii]
+
+All symbols in the installed headers are considered part of the public API.
+
+All installed headers are in the `include` directory of the package, headers in any other folders are not installed and considered private.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmw` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmw` contains C code and therefore must be concerned with ABI stability, and will maintain ABI stability within a ROS distribution.
+
+## Change Control Process [2]
+
+`rmw` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+This package requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+ This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+
+### Peer Review Policy [2.iii]
+
+ Following the recommended guidelines for ROS Core packages, all pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmw` has a [feature list](http://docs.ros2.org/latest/api/rmw/) and each item in the list links to the corresponding feature documentation.
+There is documentation for all of the features, and new features require documentation before being added.
+
+### Public API Documentation [3.ii]
+
+`rmw` has embedded API documentation and it is generated using doxygen and is [hosted](https://docs.ros2.org/eloquent/api/rmw/index.html) alongside the feature documentation.
+There is documentation for all of the public API, and new additions to the public API require documentation before being added.
+
+### License [3.iii]
+
+The license for `rmw` is Apache 2.0, and a summary is in each source file, the type is declared in the `package.xml` manifest file, and a full copy of the license is in the `LICENSE` file.
+
+There is an automated test which runs a linter that ensures each file has a license statement.
+
+Most recent test results can be found [here](http://build.ros2.org/view/Epr/job/Epr__rmw__ubuntu_bionic_amd64/lastBuild/testReport/rmw/).
+
+### Copyright Statements [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmw`.
+
+There is an automated test which runs a linter that ensures each file has at least one copyright statement.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+Some features in `rmw` have corresponding tests which simulate typical usage, and they are located in the `test` directory.
+New features are required to have tests before being added.
+
+### Public API Testing [4.ii]
+
+Much of the public API has tests, and new additions or changes to the public API require tests before being added.
+The tests aim to cover both typical usage and corner cases, but are quantified by contributing to code coverage.
+
+### Coverage [4.iii]
+
+`rmw` does not currently track test coverage.
+
+### Performance [4.iv]
+
+`rmw` does not currently have performance tests.
+
+### Linters and Static Analysis [4.v]
+
+`rmw` uses and passes all the standard linters and static analysis tools for a C++ package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+### Performance [5]
+
+TODO document performance tests
+
+`rmw` follows the recommendations for performance testing of C++ code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements), and opts to do performance analysis on each release rather than each change.
+
+### Linters and Static Analysis [4.v]
+
+`rmw` uses and passes all the standard linters and static analysis tools for a C++ package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]/[5.ii]
+
+`rmw` has the following ROS dependencies:
+* `rcutils`
+* `rosidl_runtime_c`
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+It also has several test dependencies, which do not affect the resulting quality of the package, because they are only used to build and run the test code.
+
+### Direct Runtime Non-ROS Dependencies [5.iii]
+
+`rmw` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+`rmw` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
+
+Currently nightly results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/rmw/)
+* [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/rmw/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/rmw/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/rmw/)
+
+## Vulnerability Disclosure Policy [7.i]
+
+This package does not yet have a Vulnerability Disclosure Policy

--- a/rmw/README.md
+++ b/rmw/README.md
@@ -6,3 +6,7 @@ For more information, see https://design.ros2.org/articles/ros_middleware_interf
 
 ## Interface and Features
 For specific information about the rmw interface and features, see its [api docs](http://docs.ros2.org/latest/api/rmw/).
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmw_implementation_cmake/QUALITY_DECLARATION.md
+++ b/rmw_implementation_cmake/QUALITY_DECLARATION.md
@@ -40,11 +40,11 @@ This package requires that all changes occur through a pull request.
 
 ### Contributor Origin [2.ii]
 
- This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
 
 ### Peer Review Policy [2.iii]
 
- Following the recommended guidelines for ROS Core packages, all pull requests must have at least 1 peer review.
+Following the recommended guidelines for ROS Core packages, all pull requests must have at least 1 peer review.
 
 ### Continuous Integration [2.iv]
 

--- a/rmw_implementation_cmake/QUALITY_DECLARATION.md
+++ b/rmw_implementation_cmake/QUALITY_DECLARATION.md
@@ -67,7 +67,7 @@ There is documentation for all of the public API, and new additions to the publi
 
 ### License [3.iii]
 
-The license for `rmw_implementation_cmake` is Apache 2.0, and a summary is in each source file, the type is declared in the `package.xml` manifest file, and a full copy of the license is in the `LICENSE` file.
+The license for `rmw_implementation_cmake` is Apache 2.0, and a summary is in each source file, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the [LICENSE](../LICENSE) file.
 
 There is an automated test which runs a linter that ensures each file has a license statement.
 
@@ -79,9 +79,17 @@ The copyright holders each provide a statement of copyright in each source code 
 
 There is an automated test which runs a linter that ensures each file has at least one copyright statement.
 
+Results of the copyright tests can be found [here](http://build.ros2.org/view/Epr/job/Epr__rmw__ubuntu_bionic_amd64/lastBuild/testReport/rmw_implementation_cmake/copyright/).
+
 ## Testing [4]
 
 `rmw_implementation_cmake` is a package providing solely CMake files and therefore does not require tests and has no coverage or performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmw` uses and passes all the standard linters and static analysis tools for a CMake package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+Results of linter tests can be found [here](http://build.ros2.org/view/Epr/job/Epr__rmw__ubuntu_bionic_amd64/lastBuild/testReport/rmw_implementation_cmake).
 
 ## Dependencies [5]
 

--- a/rmw_implementation_cmake/QUALITY_DECLARATION.md
+++ b/rmw_implementation_cmake/QUALITY_DECLARATION.md
@@ -1,0 +1,108 @@
+This document is a declaration of software quality for the `rmw_implementation_cmake` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmw_implementation_cmake` Quality Declaration
+
+The package `rmw_implementation_cmake` claims to be in the **Quality Level 4** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmw_implementation_cmake` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmw_implementation_cmake` is not yet at a stable version, i.e. `>= 1.0.0`.
+
+### Public API Declaration [1.iii]
+
+All symbols in the installed CMake files are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmw_implementation_cmake` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+CMake files that are not in the cmake directory are not installed, and are considered private.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmw_implementation_cmake` does not contain any c or c++ code, therefore changes will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rmw_implementation_cmake` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+This package requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+ This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+
+### Peer Review Policy [2.iii]
+
+ Following the recommended guidelines for ROS Core packages, all pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmw_implementation_cmake` does not currently document its features.
+
+### Public API Documentation [3.ii]
+
+`rmw_implementation_cmake` has embedded API documentation, and is available in its source files.
+There is documentation for all of the public API, and new additions to the public API require documentation before being added.
+
+### License [3.iii]
+
+The license for `rmw_implementation_cmake` is Apache 2.0, and a summary is in each source file, the type is declared in the `package.xml` manifest file, and a full copy of the license is in the `LICENSE` file.
+
+There is an automated test which runs a linter that ensures each file has a license statement.
+
+Most recent test results can be found [here](http://build.ros2.org/view/Epr/job/Epr__rmw_implementation_cmake__ubuntu_bionic_amd64/lastBuild/testReport/rmw_implementation_cmake/)
+
+### Copyright Statements [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmw_implementation_cmake`.
+
+There is an automated test which runs a linter that ensures each file has at least one copyright statement.
+
+## Testing [4]
+
+`rmw_implementation_cmake` is a package providing solely CMake files and therefore does not require tests and has no coverage or performance requirements.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]/[5.ii]
+
+`rmw_implementation_cmake` has only "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+It also has several test dependencies, which do not affect the resulting quality of the package, because they are only used to build and run the test code.
+
+### Direct Runtime Non-ROS Dependencies [5.iii]
+`rmw_implementation_cmake` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+`rmw_implementation_cmake` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
+
+Currently nightly results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/rmw_implementation_cmake/)
+* [linux_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/rmw_implementation_cmake/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/rmw_implementation_cmake/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/rmw_implementation_cmake/)
+
+## Vulnerability Disclosure Policy [7.i]
+
+This package does not yet have a Vulnerability Disclosure Policy

--- a/rmw_implementation_cmake/README.md
+++ b/rmw_implementation_cmake/README.md
@@ -5,6 +5,10 @@ This package provides some CMake functions to discover and enumerate available r
 ## Features
 This package provides the following CMake functions:
 
-* [call_for_each_rmw_implementation](cmake/call_for_each_rmw_implementation.cmake): Call a CMake macro for each available RMW implementation
-* [get_available_rmw_implementations](cmake/get_available_rmw_implementations.cmake): Get the package names of the available ROS middleware implementations
-* [get_default_rmw_implementation](cmake/get_default_rmw_implementation.cmake): Get the package name of the default ROS middleware implementation
+* [call_for_each_rmw_implementation](cmake/call_for_each_rmw_implementation.cmake): Call a CMake macro for each available RMW implementation.
+* [get_available_rmw_implementations](cmake/get_available_rmw_implementations.cmake): Get the package names of the available ROS middleware implementations.
+* [get_default_rmw_implementation](cmake/get_default_rmw_implementation.cmake): Get the package name of the default ROS middleware implementation.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](QUALITY_DECLARATION.md) for more details.


### PR DESCRIPTION
Including aspirational quality declarations for `rmw` and `rmw_implementation_cmake`. While this only has one commit, it does technically depend on #203 and #204 and should be rebased when they are merged.

Signed-off-by: Stephen Brawner <brawner@gmail.com>