### PR TITLE
add topic endpoint info to rmw

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -94,6 +94,7 @@ extern "C"
 #include "rosidl_generator_c/message_type_support_struct.h"
 #include "rosidl_generator_c/service_type_support_struct.h"
 
+#include "rmw/get_topic_endpoint_info.h"
 #include "rmw/init.h"
 #include "rmw/macros.h"
 #include "rmw/qos_profiles.h"


### PR DESCRIPTION
https://github.com/ros2/rmw/pull/186 introduces two functions to the RMW interface which are not present when including `rmw/rmw.h`.
For convenience to the rmw implementer, I think it makes sense to include all functions when including `rmw/rmw.h`.