### PR TITLE
rename rosidl_generator_c namespace to rosidl_runtime_c

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -90,9 +90,9 @@ extern "C"
 
 #include "rcutils/types.h"
 
-#include "rosidl_generator_c/message_bounds_struct.h"
-#include "rosidl_generator_c/message_type_support_struct.h"
-#include "rosidl_generator_c/service_type_support_struct.h"
+#include "rosidl_runtime_c/message_bounds_struct.h"
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_runtime_c/service_type_support_struct.h"
 
 #include "rmw/init.h"
 #include "rmw/macros.h"


### PR DESCRIPTION
Related to ros2/rosidl#458.