### PR TITLE
Document rmw_destroy_node may assume correct destruction order

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -177,6 +177,12 @@ rmw_create_node(
 
 /// Finalize a given node handle, reclaim the resources, and deallocate the node handle.
 /**
+ * The method may assume - but should verify - that all publishers, subscribers,
+ * services, and clients created from this node have already been destroyed.
+ * If the rmw implementation chooses to verify instead of assume, it should
+ * return `RMW_RET_ERROR` and set a human readable error message if any entity
+ * created from this node has not yet been destroyed.
+ *
  * \param node the node handle to be destroyed
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if node is null, or


### PR DESCRIPTION
I looked at three rmw implementations, `rmw_fastrtps_shared_cpp`, `rmw_connect_shared_cpp`, and `rmw_cyclone_cpp`, and it seems like they all assume higher layers destroy entities created from nodes before the node itself is destroyed. This PR documents that rmw implementations may assume this.

This also adds an option for `rmw` implementations to choose to check that assumption and refuse to destroy the node if not all entities created from it have been destroyed. No `rmw` implementation does this, but I think it would be nice if one did to make it easier to catch destruction order bugs.

Context: https://github.com/ros2/rcl/issues/585
Another PR in `rcl` documenting that the destruction order responsibility belongs to the client libraries: https://github.com/ros2/rcl/pull/625