### PR TITLE
fix missing target dependency on rosidl_runtime_c

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -66,7 +66,9 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_development_version_if_higher_than_manifest("0.8.2-dev")
-ament_package(CONFIG_EXTRAS "rmw-extras.cmake")
+ament_package(
+  CONFIG_EXTRAS "rmw-extras.cmake"
+  CONFIG_EXTRAS_POST "rmw-extras-post.cmake")
 
 install(
   DIRECTORY cmake

--- a/rmw/rmw-extras-post.cmake
+++ b/rmw/rmw-extras-post.cmake
@@ -1,0 +1,20 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# copied from rmw/rmw-extras-post.cmake
+
+# since a build dependency for the rosidl_runtime_c targets is undesired
+# they are being added to the rmw interface library here instead
+ament_target_dependencies(rmw::rmw INTERFACE
+  rosidl_runtime_c)


### PR DESCRIPTION
Related to ros2/ros2#904.

Needed for https://github.com/ros2/rmw/blob/21dc0dbf020d7e7aca7a5144465ce10b48af4a55/rmw/include/rmw/rmw.h#L93-L95.