### PR TITLE
Add message lost event

### DIFF
--- a/rmw/include/rmw/event.h
+++ b/rmw/include/rmw/event.h
@@ -29,13 +29,14 @@ extern "C"
 #include "rmw/ret_types.h"
 #include "rmw/visibility_control.h"
 
-/// Define QoS policy events
+/// Define publisher/subscription events
 typedef enum rmw_event_type_t
 {
   // subscription events
   RMW_EVENT_LIVELINESS_CHANGED,
   RMW_EVENT_REQUESTED_DEADLINE_MISSED,
   RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE,
+  RMW_EVENT_MESSAGE_LOST,
 
   // publisher events
   RMW_EVENT_LIVELINESS_LOST,

--- a/rmw/include/rmw/events_statuses/events_statuses.h
+++ b/rmw/include/rmw/events_statuses/events_statuses.h
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW__INCOMPATIBLE_QOS_EVENTS_STATUSES_H_
-#define RMW__INCOMPATIBLE_QOS_EVENTS_STATUSES_H_
+#ifndef RMW__EVENTS_STATUSES__EVENTS_STATUSES_H_
+#define RMW__EVENTS_STATUSES__EVENTS_STATUSES_H_
 
 #include "rmw/events_statuses/incompatible_qos.h"
+#include "rmw/events_statuses/liveliness_changed.h"
+#include "rmw/events_statuses/liveliness_lost.h"
+#include "rmw/events_statuses/offered_deadline_missed.h"
+#include "rmw/events_statuses/requested_deadline_missed.h"
 
-#endif  // RMW__INCOMPATIBLE_QOS_EVENTS_STATUSES_H_
+#endif  // RMW__EVENTS_STATUSES__EVENTS_STATUSES_H_

--- a/rmw/include/rmw/events_statuses/incompatible_qos.h
+++ b/rmw/include/rmw/events_statuses/incompatible_qos.h
@@ -1,0 +1,68 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW__EVENTS_STATUSES__INCOMPATIBLE_QOS_H_
+#define RMW__EVENTS_STATUSES__INCOMPATIBLE_QOS_H_
+
+#include <stdint.h>
+
+#include "rmw/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/// QoS Policy Kinds
+typedef enum RMW_PUBLIC_TYPE rmw_qos_policy_kind_t
+{
+  RMW_QOS_POLICY_INVALID = 1 << 0,
+  RMW_QOS_POLICY_DURABILITY = 1 << 1,
+  RMW_QOS_POLICY_DEADLINE = 1 << 2,
+  RMW_QOS_POLICY_LIVELINESS = 1 << 3,
+  RMW_QOS_POLICY_RELIABILITY = 1 << 4,
+  RMW_QOS_POLICY_HISTORY = 1 << 5,
+  RMW_QOS_POLICY_LIFESPAN = 1 << 6
+} rmw_qos_policy_kind_t;
+
+struct RMW_PUBLIC_TYPE rmw_qos_incompatible_event_status_t
+{
+  /**
+   * Total cumulative number of times the concerned subscription discovered a
+   * publisher for the same topic with an offered QoS that was incompatible
+   * with that requested by the subscription.
+   */
+  int32_t total_count;
+  /**
+   * The change in total_count since the last time the status was read.
+   */
+  int32_t total_count_change;
+  /**
+   * The Qos Policy Kind of one of the policies that was found to be
+   * incompatible the last time an incompatibility was detected.
+   */
+  rmw_qos_policy_kind_t last_policy_kind;
+};
+
+/// Event state for a subscription's 'RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE' events.
+typedef struct rmw_qos_incompatible_event_status_t rmw_requested_qos_incompatible_event_status_t;
+
+/// Event state for a publisher's 'RMW_EVENT_OFFERED_QOS_INCOMPATIBLE' events.
+typedef struct rmw_qos_incompatible_event_status_t rmw_offered_qos_incompatible_event_status_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RMW__EVENTS_STATUSES__INCOMPATIBLE_QOS_H_

--- a/rmw/include/rmw/events_statuses/liveliness_changed.h
+++ b/rmw/include/rmw/events_statuses/liveliness_changed.h
@@ -1,0 +1,58 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW__EVENTS_STATUSES__LIVELINESS_CHANGED_H_
+#define RMW__EVENTS_STATUSES__LIVELINESS_CHANGED_H_
+
+#include <stdint.h>
+
+#include "rmw/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/// QoS Liveliness Changed information provided by a subscription.
+typedef struct RMW_PUBLIC_TYPE rmw_liveliness_changed_status_t
+{
+  /**
+   * The total number of currently active Publishers which publish to the topic associated with
+   * the Subscription.
+   * This count increases when a newly matched Publisher asserts its liveliness for the first time
+   * or when a Publisher previously considered to be not alive reasserts its liveliness.
+   * The count decreases when a Publisher considered alive fails to assert its liveliness and
+   * becomes not alive, whether because it was deleted normally or for some other reason.
+   */
+  int32_t alive_count;
+  /**
+   * The total count of current Publishers which publish to the topic associated with the
+   * Subscription that are no longer asserting their liveliness.
+   * This count increases when a Publisher considered alive fails to assert its liveliness and
+   * becomes not alive for some reason other than the normal deletion of that Publisher.
+   * It decreases when a previously not alive Publisher either reasserts its liveliness or is
+   * deleted normally.
+   */
+  int32_t not_alive_count;
+  /// The change in the alive_count since the status was last read.
+  int32_t alive_count_change;
+  /// The change in the not_alive_count since the status was last read.
+  int32_t not_alive_count_change;
+} rmw_liveliness_changed_status_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RMW__EVENTS_STATUSES__LIVELINESS_CHANGED_H_

--- a/rmw/include/rmw/events_statuses/liveliness_lost.h
+++ b/rmw/include/rmw/events_statuses/liveliness_lost.h
@@ -1,0 +1,45 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW__EVENTS_STATUSES__LIVELINESS_LOST_H_
+#define RMW__EVENTS_STATUSES__LIVELINESS_LOST_H_
+
+#include <stdint.h>
+
+#include "rmw/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/// QoS Liveliness Lost information provided by a publisher.
+typedef struct RMW_PUBLIC_TYPE rmw_liveliness_lost_status_t
+{
+  /**
+   * Lifetime cumulative number of times that a previously-alive Publisher became not alive due to
+   * a failure to actively signal its liveliness within its offered liveliness period.
+   * This count does not change when an already not alive Publisher simply remains not alive for
+   * another liveliness period.
+   */
+  int32_t total_count;
+  /// The change in total_count since the last time the status was last read.
+  int32_t total_count_change;
+} rmw_liveliness_lost_status_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RMW__EVENTS_STATUSES__LIVELINESS_LOST_H_

--- a/rmw/include/rmw/events_statuses/message_lost.h
+++ b/rmw/include/rmw/events_statuses/message_lost.h
@@ -12,14 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW__EVENTS_STATUSES__EVENTS_STATUSES_H_
-#define RMW__EVENTS_STATUSES__EVENTS_STATUSES_H_
+#ifndef RMW__EVENTS_STATUSES__MESSAGE_LOST_H_
+#define RMW__EVENTS_STATUSES__MESSAGE_LOST_H_
 
-#include "rmw/events_statuses/incompatible_qos.h"
-#include "rmw/events_statuses/liveliness_changed.h"
-#include "rmw/events_statuses/liveliness_lost.h"
-#include "rmw/events_statuses/message_lost.h"
-#include "rmw/events_statuses/offered_deadline_missed.h"
-#include "rmw/events_statuses/requested_deadline_missed.h"
+#include <stddef.h>
 
-#endif  // RMW__EVENTS_STATUSES__EVENTS_STATUSES_H_
+#include "rmw/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct RMW_PUBLIC_TYPE rmw_message_lost_status_t
+{
+  /// Total number of messages lost.
+  size_t total_count;
+  /// Number of messages lost since last callback.
+  size_t total_count_change;
+} rmw_message_lost_status_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RMW__EVENTS_STATUSES__MESSAGE_LOST_H_

--- a/rmw/include/rmw/events_statuses/offered_deadline_missed.h
+++ b/rmw/include/rmw/events_statuses/offered_deadline_missed.h
@@ -1,0 +1,45 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW__EVENTS_STATUSES__OFFERED_DEADLINE_MISSED_H_
+#define RMW__EVENTS_STATUSES__OFFERED_DEADLINE_MISSED_H_
+
+#include <stddef.h>
+
+#include "rmw/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/// QoS Deadline Missed information provided by a publisher.
+typedef struct RMW_PUBLIC_TYPE rmw_offered_deadline_missed_status_t
+{
+  /**
+   * Lifetime cumulative number of offered deadline periods elapsed during which a Publisher failed
+   * to provide data.
+   * Missed deadlines accumulate; that is, each deadline period the total_count will be incremented
+   * by one.
+   */
+  int32_t total_count;
+  /// The change in total_count since the last time the status was last read.
+  int32_t total_count_change;
+} rmw_offered_deadline_missed_status_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RMW__EVENTS_STATUSES__OFFERED_DEADLINE_MISSED_H_

--- a/rmw/include/rmw/events_statuses/requested_deadline_missed.h
+++ b/rmw/include/rmw/events_statuses/requested_deadline_missed.h
@@ -1,0 +1,45 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW__EVENTS_STATUSES__REQUESTED_DEADLINE_MISSED_H_
+#define RMW__EVENTS_STATUSES__REQUESTED_DEADLINE_MISSED_H_
+
+#include <stdint.h>
+
+#include "rmw/visibility_control.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/// QoS Requested Deadline Missed information provided by a subscription.
+typedef struct RMW_PUBLIC_TYPE rmw_requested_deadline_missed_status_t
+{
+  /**
+   * Lifetime cumulative number of missed deadlines detected for any instance read by the
+   * subscription.
+   * Missed deadlines accumulate; that is, each deadline period the total_count will be incremented
+   * by one for each instance for which data was not received.
+   */
+  int32_t total_count;
+  /// The incremental number of deadlines detected since the status was read.
+  int32_t total_count_change;
+} rmw_requested_deadline_missed_status_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RMW__EVENTS_STATUSES__REQUESTED_DEADLINE_MISSED_H_

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -27,6 +27,7 @@ extern "C"
 // map rcutils specific log levels to rmw speicfic type
 #include <rcutils/logging.h>
 
+#include "rmw/events_statuses/events_statuses.h"
 #include "rmw/init.h"
 #include "rmw/init_options.h"
 #include "rmw/ret_types.h"
@@ -513,75 +514,6 @@ typedef enum RMW_PUBLIC_TYPE
   /// Fatal log severity, for reporting issue causing imminent shutdown
   RMW_LOG_SEVERITY_FATAL = RCUTILS_LOG_SEVERITY_FATAL
 } rmw_log_severity_t;
-
-/// QoS Liveliness Changed information provided by a subscription.
-typedef struct RMW_PUBLIC_TYPE rmw_liveliness_changed_status_t
-{
-  /**
-   * The total number of currently active Publishers which publish to the topic associated with
-   * the Subscription.
-   * This count increases when a newly matched Publisher asserts its liveliness for the first time
-   * or when a Publisher previously considered to be not alive reasserts its liveliness.
-   * The count decreases when a Publisher considered alive fails to assert its liveliness and
-   * becomes not alive, whether because it was deleted normally or for some other reason.
-   */
-  int32_t alive_count;
-  /**
-   * The total count of current Publishers which publish to the topic associated with the
-   * Subscription that are no longer asserting their liveliness.
-   * This count increases when a Publisher considered alive fails to assert its liveliness and
-   * becomes not alive for some reason other than the normal deletion of that Publisher.
-   * It decreases when a previously not alive Publisher either reasserts its liveliness or is
-   * deleted normally.
-   */
-  int32_t not_alive_count;
-  /// The change in the alive_count since the status was last read.
-  int32_t alive_count_change;
-  /// The change in the not_alive_count since the status was last read.
-  int32_t not_alive_count_change;
-} rmw_liveliness_changed_status_t;
-
-/// QoS Requested Deadline Missed information provided by a subscription.
-typedef struct RMW_PUBLIC_TYPE rmw_requested_deadline_missed_status_t
-{
-  /**
-   * Lifetime cumulative number of missed deadlines detected for any instance read by the
-   * subscription.
-   * Missed deadlines accumulate; that is, each deadline period the total_count will be incremented
-   * by one for each instance for which data was not received.
-   */
-  int32_t total_count;
-  /// The incremental number of deadlines detected since the status was read.
-  int32_t total_count_change;
-} rmw_requested_deadline_missed_status_t;
-
-/// QoS Liveliness Lost information provided by a publisher.
-typedef struct RMW_PUBLIC_TYPE rmw_liveliness_lost_status_t
-{
-  /**
-   * Lifetime cumulative number of times that a previously-alive Publisher became not alive due to
-   * a failure to actively signal its liveliness within its offered liveliness period.
-   * This count does not change when an already not alive Publisher simply remains not alive for
-   * another liveliness period.
-   */
-  int32_t total_count;
-  /// The change in total_count since the last time the status was last read.
-  int32_t total_count_change;
-} rmw_liveliness_lost_status_t;
-
-/// QoS Deadline Missed information provided by a publisher.
-typedef struct RMW_PUBLIC_TYPE rmw_offered_deadline_missed_status_t
-{
-  /**
-   * Lifetime cumulative number of offered deadline periods elapsed during which a Publisher failed
-   * to provide data.
-   * Missed deadlines accumulate; that is, each deadline period the total_count will be incremented
-   * by one.
-   */
-  int32_t total_count;
-  /// The change in total_count since the last time the status was last read.
-  int32_t total_count_change;
-} rmw_offered_deadline_missed_status_t;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
See https://github.com/ros2/rmw/issues/226.

[First commit](https://github.com/ros2/rmw/commit/79781321003095ce8ac3b17781d1154fdc423cae) reorganizes event statuses headers in a subfolder, so we stop populating the old big `rmw/types.h` (the old headers are still including the new ones, to avoid creating a bunch of PRs together with this one).

[The second commit](https://github.com/ros2/rmw/commit/84e5b29afda22bf4e139b0a1104948c32455ff28) actually implements what the title says.