### PR TITLE
Fix rmw_names_and_types_fini test to address issue #234

### DIFF
--- a/rmw/test/test_names_and_types.cpp
+++ b/rmw/test/test_names_and_types.cpp
@@ -108,6 +108,7 @@ TEST(rmw_names_and_types, rmw_names_and_types_init) {
 
   result = rmw_names_and_types_init(&names_and_types, size, &allocator);
   EXPECT_EQ(result, RMW_RET_OK);
+  EXPECT_EQ(rmw_names_and_types_fini(&names_and_types), RMW_RET_OK);
 }
 
 TEST(rmw_names_and_types, rmw_names_and_types_fini) {
@@ -118,22 +119,30 @@ TEST(rmw_names_and_types, rmw_names_and_types_fini) {
   rmw_ret_t result = rmw_names_and_types_init(&names_and_types, size, &allocator);
   EXPECT_EQ(result, RMW_RET_OK);
 
+  // Ok
+  EXPECT_EQ(rmw_names_and_types_fini(&names_and_types), RMW_RET_OK);
+  result = rmw_names_and_types_init(&names_and_types, size, &allocator);
+  EXPECT_EQ(result, RMW_RET_OK);
+
   // names_and_types is nullptr
   EXPECT_EQ(rmw_names_and_types_fini(nullptr), RMW_RET_INVALID_ARGUMENT);
   rmw_reset_error();
-
-  // Ok
-  EXPECT_EQ(rmw_names_and_types_fini(&names_and_types), RMW_RET_OK);
 
   // Size != 0 and types is null
   auto types_ptr = names_and_types.types;
   names_and_types.types = nullptr;
   EXPECT_EQ(rmw_names_and_types_fini(&names_and_types), RMW_RET_INVALID_ARGUMENT);
   rmw_reset_error();
-  names_and_types.types = types_ptr;
 
   // bad allocator, rcutils fails to finalize string array
   names_and_types.names.allocator.deallocate = nullptr;
+  names_and_types.names.size = 0u;
+  names_and_types.types = nullptr;
   EXPECT_EQ(rmw_names_and_types_fini(&names_and_types), RMW_RET_INVALID_ARGUMENT);
   rmw_reset_error();
+
+  names_and_types.types = types_ptr;
+  names_and_types.names.size = 100;
+  names_and_types.names.allocator = rcutils_get_default_allocator();
+  EXPECT_EQ(rmw_names_and_types_fini(&names_and_types), RMW_RET_OK);
 }


### PR DESCRIPTION
After recent PR in rcutils (https://github.com/ros2/rcutils/pull/247), this test `rmw_names_and_types_init` had some fragile assumptions break, which were reported in issue #234. It also reinitializes names_and_types after it successfully finalizes it the first time, which was another issue.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11085)](http://ci.ros2.org/job/ci_linux/11085/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6393)](http://ci.ros2.org/job/ci_linux-aarch64/6393/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9040)](http://ci.ros2.org/job/ci_osx/9040/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10995)](http://ci.ros2.org/job/ci_windows/10995/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>