### PR TITLE
Add atexit helper

### DIFF
--- a/rmw/include/rmw/impl/cpp/atexit.hpp
+++ b/rmw/include/rmw/impl/cpp/atexit.hpp
@@ -1,0 +1,63 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW__IMPL__CPP__ATEXIT_HPP_
+#define RMW__IMPL__CPP__ATEXIT_HPP_
+
+#include <functional>
+#include <utility>
+
+namespace rmw
+{
+namespace impl
+{
+namespace cpp
+{
+
+class atexit final
+{
+public:
+  using callable_type = std::function<void (void)>;
+
+  explicit atexit(callable_type callable)
+  : callable_(std::move(callable))
+  {
+  }
+
+  atexit(const atexit & other) = delete;
+  atexit(atexit && other) = delete;
+  atexit & operator=(const atexit & other) = delete;
+  atexit & operator=(atexit && other) = delete;
+
+  ~atexit()
+  {
+    if (callable_) {
+      callable_();
+    }
+  }
+
+  void cancel()
+  {
+    callable_ = nullptr;
+  }
+
+private:
+  callable_type callable_;
+};
+
+}  // namespace cpp
+}  // namespace impl
+}  // namespace rmw
+
+#endif  // RMW__IMPL__CPP__ATEXIT_HPP_

--- a/rmw/test/CMakeLists.txt
+++ b/rmw/test/CMakeLists.txt
@@ -172,3 +172,12 @@ if(TARGET test_topic_endpoint_info)
   target_link_libraries(test_topic_endpoint_info ${PROJECT_NAME}
   osrf_testing_tools_cpp::memory_tools)
 endif()
+
+ament_add_gmock(test_impl_cpp_atexit
+  impl/cpp/test_atexit.cpp
+  # Append the directory of librmw so it is found at test time.
+  APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
+)
+if(TARGET test_impl_cpp_atexit)
+  target_link_libraries(test_impl_cpp_atexit ${PROJECT_NAME})
+endif()

--- a/rmw/test/impl/cpp/test_atexit.cpp
+++ b/rmw/test/impl/cpp/test_atexit.cpp
@@ -1,0 +1,42 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gmock/gmock.h"
+
+#include "rmw/impl/cpp/atexit.hpp"
+
+TEST(test_atexit, should_run) {
+  bool called = false;
+
+  {
+    rmw::impl::cpp::atexit{[&called]() {
+        called = true;
+      }};
+  }
+
+  EXPECT_TRUE(called);
+}
+
+TEST(test_atexit, should_not_run) {
+  bool called = false;
+
+  {
+    rmw::impl::cpp::atexit test{[&called]() {
+        called = true;
+      }};
+    test.cancel();
+  }
+
+  EXPECT_FALSE(called);
+}


### PR DESCRIPTION
A dumb helper to minimize and simplify cleanup logic in `rmw` implementations.