### PR TITLE
Update publisher/subscription QoS query API documentation.

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -478,7 +478,7 @@ rmw_publisher_count_matched_subscriptions(
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------
- * Allocates Memory   | No
+ * Allocates Memory   | Maybe [1]
  * Thread-Safe        | No
  * Uses Atomics       | Maybe [1]
  * Lock-Free          | Maybe [1]
@@ -795,7 +795,7 @@ rmw_subscription_count_matched_publishers(
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------
- * Allocates Memory   | No
+ * Allocates Memory   | Maybe [1]
  * Thread-Safe        | No
  * Uses Atomics       | Maybe [1]
  * Lock-Free          | Maybe [1]

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -470,14 +470,26 @@ rmw_publisher_count_matched_subscriptions(
  * depends on the underlying rmw implementation.
  * If the underlying setting in use can't be represented in ROS terms,
  * it will be set to RMW_*_UNKNOWN.
- * The value of avoid_ros_namespace_conventions field is not resolved
- * with this function. The rcl function rcl_publisher_get_actual_qos
- * resolves it.
+ *
+ * \note The value of avoid_ros_namespace_conventions field is not resolved
+ *   with this function. The rcl function `rcl_publisher_get_actual_qos()`
+ *   resolves it.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | Maybe [1]
+ * Lock-Free          | Maybe [1]
+ * <i>[1] rmw implementation defined, check the implementation documentation</i>
  *
  * \param[in] publisher the publisher object to inspect
  * \param[out] qos the actual qos settings
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if either argument is null, or
+ * \return `RMW_RET_INCORRECT_RMW_IMPLEMENTATION` if publisher
+ *   implementation identifier does not match, or
  * \return `RMW_RET_ERROR` if an unexpected error occurs.
  */
 RMW_PUBLIC
@@ -775,9 +787,19 @@ rmw_subscription_count_matched_publishers(
  * depends on the underlying rmw implementation.
  * If the underlying setting in use can't be represented in ROS terms,
  * it will be set to RMW_*_UNKNOWN.
- * The value of avoid_ros_namespace_conventions field is not resolved
- * with this function. The rcl function rcl_subscription_get_actual_qos
- * resolves it.
+ *
+ * \note The value of avoid_ros_namespace_conventions field is not resolved
+ *   with this function. The rcl function `rcl_subscription_get_actual_qos()`
+ *   resolves it.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | Maybe [1]
+ * Lock-Free          | Maybe [1]
+ * <i>[1] rmw implementation defined, check the implementation documentation</i>
  *
  * \param[in] subscription the subscription object to inspect
  * \param[out] qos the actual qos settings


### PR DESCRIPTION
Follow-up after 0176872b10ff502ae34fa3eef5e900145f18b0b3 (#256).
