### PR TITLE
Update rmw_get_serialized_message_size docblock

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -768,6 +768,7 @@ rmw_publish_serialized_message(
  * \param[out] size The computed size of the serialized message.
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if either argument is null, or
+ * \return `RMW_RET_UNSUPPORTED` if it's unimplemented, or
  * \return `RMW_RET_ERROR` if an unexpected error occurs.
  */
 RMW_PUBLIC


### PR DESCRIPTION
Update rmw_get_serialized_message_size docblock to return the right error code.

Signed-off-by: ahcorde <ahcorde@gmail.com>