### PR TITLE
Deprecate rmw_time_t

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -2414,7 +2414,7 @@ rmw_destroy_wait_set(rmw_wait_set_t * wait_set);
  * \param[inout] events Array of events to wait on.
  *   Can be `NULL` if there are no events to wait on.
  * \param[in] wait_set Wait set to use for waiting.
- * \param[in] wait_timeout If `NULL`, block indefinitely until an entity becomes ready.
+ * \param[in] wait_timeout If negative, block indefinitely until an entity becomes ready.
  *   If zero, do not block -- check only for immediately available entities.
  *   Else, this represents the maximum amount of time to wait for an entity to become ready.
  * \return `RMW_RET_OK` if successful, or
@@ -2435,7 +2435,7 @@ rmw_wait(
   rmw_clients_t * clients,
   rmw_events_t * events,
   rmw_wait_set_t * wait_set,
-  const rmw_time_t * wait_timeout);
+  rmw_duration_t wait_timeout);
 
 /// Return the name and namespace of all nodes in the ROS graph.
 /**

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -333,7 +333,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_time_t
   /// Nanoseconds component of this time point
   uint64_t nsec;
 } RMW_DECLARE_DEPRECATED (rmw_time_t,
-  "rmw_time_t has been deprecated in G-Turtle in favor of rmw_duration_t. "
+  "rmw_time_t has been deprecated in Galactic in favor of rmw_duration_t. "
   "It will be removed in H-Turtle");
 
 /// A duration of time, measured in nanoseconds.

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -39,6 +39,12 @@ extern "C"
 // implementation. It may need to be increased in the future.
 #define RMW_GID_STORAGE_SIZE 24u
 
+#ifndef _WIN32
+# define RMW_DECLARE_DEPRECATED(name, msg) name __attribute__((deprecated(msg)))
+#else
+# define RMW_DECLARE_DEPRECATED(name, msg) name __pragma(deprecated(name))
+#endif
+
 /// Structure which encapsulates an rmw node
 typedef struct RMW_PUBLIC_TYPE rmw_node_t
 {
@@ -326,7 +332,12 @@ typedef struct RMW_PUBLIC_TYPE rmw_time_t
 
   /// Nanoseconds component of this time point
   uint64_t nsec;
-} rmw_time_t;
+} RMW_DECLARE_DEPRECATED (rmw_time_t,
+  "rmw_time_t has been deprecated in G-Turtle in favor of rmw_duration_t. "
+  "It will be removed in H-Turtle");
+
+/// A duration of time, measured in nanoseconds.
+typedef rcutils_duration_value_t rmw_duration_t;
 
 typedef rcutils_time_point_value_t rmw_time_point_value_t;
 
@@ -389,11 +400,6 @@ enum RMW_PUBLIC_TYPE rmw_qos_durability_policy_t
   "RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE is deprecated. " \
   "Use RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC if manually asserted liveliness is needed."
 
-#ifndef _WIN32
-# define RMW_DECLARE_DEPRECATED(name, msg) name __attribute__((deprecated(msg)))
-#else
-# define RMW_DECLARE_DEPRECATED(name, msg) name __pragma(deprecated(name))
-#endif
 
 /// QoS liveliness enumerations that describe a publisher's reporting policy for its alive status.
 /// For a subscriber, these are its requirements for its topic's publishers.
@@ -425,13 +431,13 @@ enum RMW_PUBLIC_TYPE rmw_qos_liveliness_policy_t
 };
 
 /// QoS Deadline default, 0s indicates deadline policies are not tracked or enforced
-#define RMW_QOS_DEADLINE_DEFAULT {0, 0}
+#define RMW_QOS_DEADLINE_DEFAULT 0
 
 /// QoS Lifespan default, 0s indicate lifespan policies are not tracked or enforced
-#define RMW_QOS_LIFESPAN_DEFAULT {0, 0}
+#define RMW_QOS_LIFESPAN_DEFAULT 0
 
 /// QoS Liveliness lease duration default, 0s indicate lease durations are not tracked or enforced
-#define RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT {0, 0}
+#define RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT 0
 
 /// ROS MiddleWare quality of service profile.
 typedef struct RMW_PUBLIC_TYPE rmw_qos_profile_t
@@ -444,13 +450,13 @@ typedef struct RMW_PUBLIC_TYPE rmw_qos_profile_t
   /// Durability QoS policy setting
   enum rmw_qos_durability_policy_t durability;
   /// The period at which messages are expected to be sent/received
-  struct rmw_time_t deadline;
+  rmw_duration_t deadline;
   /// The age at which messages are considered expired and no longer valid
-  struct rmw_time_t lifespan;
+  rmw_duration_t lifespan;
   /// Liveliness QoS policy setting
   enum rmw_qos_liveliness_policy_t liveliness;
   /// The time within which the RMW node or publisher must show that it is alive
-  struct rmw_time_t liveliness_lease_duration;
+  rmw_duration_t liveliness_lease_duration;
 
   /// If true, any ROS specific namespacing conventions will be circumvented.
   /**

--- a/rmw/test/test_topic_endpoint_info.cpp
+++ b/rmw/test/test_topic_endpoint_info.cpp
@@ -15,6 +15,7 @@
 #include "gmock/gmock.h"
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcutils/allocator.h"
+#include "rcutils/time.h"
 
 #include "rmw/error_handling.h"
 #include "rmw/topic_endpoint_info.h"
@@ -173,13 +174,13 @@ TEST(test_topic_endpoint_info, set_qos_profile) {
   EXPECT_EQ(
     topic_endpoint_info.qos_profile.durability,
     RMW_QOS_POLICY_DURABILITY_VOLATILE) << "Unequal durability";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.deadline, RCUTILS_S_TO_NS(1)) << "Unequal deadline";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.lifespan, RCUTILS_S_TO_NS(2u)) << "Unequal lifespan";
+  EXPECT_EQ(topic_endpoint_info.qos_profile.deadline, RCUTILS_S_TO_NS(1LL)) << "Unequal deadline";
+  EXPECT_EQ(topic_endpoint_info.qos_profile.lifespan, RCUTILS_S_TO_NS(2LL)) << "Unequal lifespan";
   EXPECT_EQ(
     topic_endpoint_info.qos_profile.liveliness,
     RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC) << "Unequal liveliness";
   EXPECT_EQ(
-    topic_endpoint_info.qos_profile.liveliness_lease_duration, RCUTILS_S_TO_NS(3u)
+    topic_endpoint_info.qos_profile.liveliness_lease_duration, RCUTILS_S_TO_NS(3LL)
   ) << "Unequal liveliness lease duration";
   EXPECT_EQ(
     topic_endpoint_info.qos_profile.avoid_ros_namespace_conventions,

--- a/rmw/test/test_topic_endpoint_info.cpp
+++ b/rmw/test/test_topic_endpoint_info.cpp
@@ -146,10 +146,10 @@ TEST(test_topic_endpoint_info, set_qos_profile) {
   qos_profile.depth = 0;
   qos_profile.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   qos_profile.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-  qos_profile.deadline = {1, 0};
-  qos_profile.lifespan = {2, 0};
+  qos_profile.deadline = RCUTILS_S_TO_NS(1);
+  qos_profile.lifespan = RCUTILS_S_TO_NS(2);
   qos_profile.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
-  qos_profile.liveliness_lease_duration = {3, 0};
+  qos_profile.liveliness_lease_duration = RCUTILS_S_TO_NS(3);
   qos_profile.avoid_ros_namespace_conventions = false;
 
   rmw_ret_t ret = rmw_topic_endpoint_info_set_qos_profile(nullptr, &qos_profile);
@@ -173,19 +173,14 @@ TEST(test_topic_endpoint_info, set_qos_profile) {
   EXPECT_EQ(
     topic_endpoint_info.qos_profile.durability,
     RMW_QOS_POLICY_DURABILITY_VOLATILE) << "Unequal durability";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.deadline.sec, 1u) << "Unequal deadline sec";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.deadline.nsec, 0u) << "Unequal deadline nsec";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.lifespan.sec, 2u) << "Unequal lifespan sec";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.lifespan.nsec, 0u) << "Unequal lifespan nsec";
+  EXPECT_EQ(topic_endpoint_info.qos_profile.deadline, RCUTILS_S_TO_NS(1)) << "Unequal deadline";
+  EXPECT_EQ(topic_endpoint_info.qos_profile.lifespan, RCUTILS_S_TO_NS(2u)) << "Unequal lifespan";
   EXPECT_EQ(
     topic_endpoint_info.qos_profile.liveliness,
     RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC) << "Unequal liveliness";
   EXPECT_EQ(
-    topic_endpoint_info.qos_profile.liveliness_lease_duration.sec,
-    3u) << "Unequal liveliness lease duration sec";
-  EXPECT_EQ(
-    topic_endpoint_info.qos_profile.liveliness_lease_duration.nsec,
-    0u) << "Unequal liveliness lease duration nsec";
+    topic_endpoint_info.qos_profile.liveliness_lease_duration, RCUTILS_S_TO_NS(3u)
+  ) << "Unequal liveliness lease duration";
   EXPECT_EQ(
     topic_endpoint_info.qos_profile.avoid_ros_namespace_conventions,
     false) << "Unequal avoid namespace conventions";
@@ -205,17 +200,12 @@ TEST(test_topic_endpoint_info, zero_init) {
   EXPECT_EQ(topic_endpoint_info.qos_profile.depth, 0u) << "Non-zero depth";
   EXPECT_EQ(topic_endpoint_info.qos_profile.reliability, 0) << "Non-zero reliability";
   EXPECT_EQ(topic_endpoint_info.qos_profile.durability, 0) << "Non-zero durability";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.deadline.sec, 0u) << "Non-zero deadline sec";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.deadline.nsec, 0u) << "Non-zero deadline nsec";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.lifespan.sec, 0u) << "Non-zero lifespan sec";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.lifespan.nsec, 0u) << "Non-zero lifespan nsec";
+  EXPECT_EQ(topic_endpoint_info.qos_profile.deadline, 0) << "Non-zero deadline";
+  EXPECT_EQ(topic_endpoint_info.qos_profile.lifespan, 0) << "Non-zero lifespan";
   EXPECT_EQ(topic_endpoint_info.qos_profile.liveliness, 0) << "Non-zero liveliness";
   EXPECT_EQ(
-    topic_endpoint_info.qos_profile.liveliness_lease_duration.sec,
-    0u) << "Non-zero liveliness lease duration sec";
-  EXPECT_EQ(
-    topic_endpoint_info.qos_profile.liveliness_lease_duration.nsec,
-    0u) << "Non-zero liveliness lease duration nsec";
+    topic_endpoint_info.qos_profile.liveliness_lease_duration,
+    0) << "Non-zero liveliness lease duration";
   EXPECT_EQ(
     topic_endpoint_info.qos_profile.avoid_ros_namespace_conventions,
     false) << "Non-zero avoid namespace conventions";
@@ -229,10 +219,10 @@ TEST(test_topic_endpoint_info, fini) {
   qos_profile.depth = 0;
   qos_profile.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   qos_profile.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-  qos_profile.deadline = {1, 0};
-  qos_profile.lifespan = {2, 0};
+  qos_profile.deadline = RCUTILS_S_TO_NS(1);
+  qos_profile.lifespan = RCUTILS_S_TO_NS(2);
   qos_profile.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
-  qos_profile.liveliness_lease_duration = {3, 0};
+  qos_profile.liveliness_lease_duration = RCUTILS_S_TO_NS(3);
   qos_profile.avoid_ros_namespace_conventions = false;
   rmw_ret_t ret = rmw_topic_endpoint_info_set_qos_profile(&topic_endpoint_info, &qos_profile);
   EXPECT_EQ(ret, RMW_RET_OK) << "Expected OK for valid arguments";
@@ -277,15 +267,11 @@ TEST(test_topic_endpoint_info, fini) {
   EXPECT_EQ(topic_endpoint_info.qos_profile.depth, 0u) << "Non-zero depth";
   EXPECT_EQ(topic_endpoint_info.qos_profile.reliability, 0) << "Non-zero reliability";
   EXPECT_EQ(topic_endpoint_info.qos_profile.durability, 0) << "Non-zero durability";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.deadline.sec, 0u) << "Non-zero deadline sec";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.deadline.nsec, 0u) << "Non-zero deadline nsec";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.lifespan.sec, 0u) << "Non-zero lifespan sec";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.lifespan.nsec, 0u) << "Non-zero lifespan nsec";
+  EXPECT_EQ(topic_endpoint_info.qos_profile.deadline, 0u) << "Non-zero deadline";
+  EXPECT_EQ(topic_endpoint_info.qos_profile.lifespan, 0u) << "Non-zero lifespan";
   EXPECT_EQ(topic_endpoint_info.qos_profile.liveliness, 0) << "Non-zero liveliness";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.liveliness_lease_duration.sec, 0u) <<
-    "Non-zero liveliness lease duration sec";
-  EXPECT_EQ(topic_endpoint_info.qos_profile.liveliness_lease_duration.nsec, 0u) <<
-    "Non-zero liveliness lease duration nsec";
+  EXPECT_EQ(topic_endpoint_info.qos_profile.liveliness_lease_duration, 0u) <<
+    "Non-zero liveliness lease duration";
   EXPECT_EQ(topic_endpoint_info.qos_profile.avoid_ros_namespace_conventions, false) <<
     "Non-zero avoid namespace conventions";
 }


### PR DESCRIPTION
Resolves #215

Removes `rmw_time_t` from the RMW API in favor of an int-based nanosecond type.
This simplifies most time-based code in the core, since rcl, rclcpp, and rclpy (and cyclonedds) all use an int64-based nanosecond timestamp already - it's a net-negative code change.

This should make #255 a lot easier to define - no special allowances will be needed around conversions to and from duration representations, nor can there be non-normalized durations (nanoseconds > 1billion)

Linked PRs:
* [ ] https://github.com/ros2/rmw_implementation/pull/178
* [ ] https://github.com/ros2/rmw_dds_common/pull/43
* [ ] https://github.com/ros2/rmw_cyclonedds/pull/283
* [ ] https://github.com/ros2/rmw_fastrtps/pull/508
* [ ] https://github.com/ros2/rmw_connext/pull/485
* [ ] https://github.com/ros2/rcl/pull/889
* [ ] https://github.com/ros2/rclcpp/pull/1549
* [ ] https://github.com/ros2/rclpy/pull/679
* [ ] https://github.com/ros2/rosbag2/pull/646
* [ ] https://github.com/ros2/demos/pull/484


Gist: https://gist.githubusercontent.com/emersonknapp/32eb5733086c7f6876e4bf9ece5d5fef/raw/caa6d31a0a84866cbc4e51afb60ad8b551a05acd/ros2.repos
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13700)](http://ci.ros2.org/job/ci_linux/13700/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8577)](http://ci.ros2.org/job/ci_linux-aarch64/8577/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11416)](http://ci.ros2.org/job/ci_osx/11416/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13783)](https://ci.ros2.org/job/ci_windows/13783/)