### PR TITLE
Add declaration for function to check QoS profile compatibility

### DIFF
--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -169,6 +169,7 @@ typedef enum RMW_PUBLIC_TYPE rmw_qos_compatibility_type_t
  * \return `RMW_RET_OK` if the check was successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `compatiblity` is NULL, or
  * \return `RMW_RET_INVALID_ARGUMENT` if any of the policies have value "unknown".
+ * \return `RMW_RET_ERROR` if there is an unexpected error.
  */
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -134,10 +134,21 @@ typedef enum RMW_PUBLIC_TYPE rmw_qos_compatibility_type_t
  * If any of the profile policies has the value "system default", then it may not be
  * possible to determine the compatibilty.
  * In this case, the output parameter `compatibility` is set to `RMW_QOS_COMPATIBILITY_WARNING`
- * and `reason` is populated
+ * and `reason` is populated.
  *
  * Profile policies must not have the value "unknown". An "unknown" value is considered an error
  * and `RMW_RET_INVALID_ARGUMENT` is returned.
+ * `reason` will be set, identifying the offending policy.
+ *
+ * If there is a compatibility warning or error, and a buffer is provided for `reason`, then an
+ * explanation of all warnings and errors will be populated into the buffer, separated by
+ * semi-colons (`;`).
+ * Errors will appear before warnings in the string buffer.
+ * If the provided buffer is not large enough, this function will still write to the buffer, up to
+ * the `reason_size` number of characters.
+ * Therefore, it is possible that not errors and warnings are communicated if the buffer size limit
+ * is reached.
+ * A buffer size of 2048 should be more than enough to capture all possible errors and warnings.
  *
  * <hr>
  * Attribute          | Adherence

--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -136,8 +136,8 @@ typedef enum RMW_PUBLIC_TYPE rmw_qos_compatibility_type_t
  * In this case, the output parameter `compatibility` is set to `RMW_QOS_COMPATIBILITY_WARNING`
  * and `reason` is populated
  *
- * Profile policies must not have the value "unknown". This is considered an error, and the
- * output parameter `compatiblity` is not set.
+ * Profile policies must not have the value "unknown". An "unknown" value is considered an error
+ * and `RMW_RET_INVALID_ARGUMENT` is returned.
  *
  * <hr>
  * Attribute          | Adherence
@@ -156,7 +156,8 @@ typedef enum RMW_PUBLIC_TYPE rmw_qos_compatibility_type_t
  *   Must be pre-allocated by the caller. This parameter is optional and may be set to `NULL`.
  * \param[in] reason_size: Size of the string buffer `reason`, if one is provided.
  * \return `RMW_RET_OK` if the check was successful, or
- * \return `RMW_RET_INVALID_ARGUMENT` if any of the policies have value "unknown"
+ * \return `RMW_RET_INVALID_ARGUMENT` if `compatiblity` is NULL, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if any of the policies have value "unknown".
  */
 RMW_PUBLIC
 RMW_WARN_UNUSED

--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -113,29 +113,60 @@ static const rmw_qos_profile_t rmw_qos_profile_unknown =
   false
 };
 
+typedef enum RMW_PUBLIC_TYPE rmw_qos_compatibility_type_t
+{
+  /// QoS policies are compatible
+  RMW_QOS_COMPATIBILITY_OK = 0,
+
+  /// QoS policies may not be compatible
+  RMW_QOS_COMPATIBILITY_WARNING,
+
+  /// QoS policies are not compatible
+  RMW_QOS_COMPATIBILITY_ERROR
+} rmw_qos_compatibility_type_t;
+
+
 /// Check if two QoS profiles are compatible.
 /**
- * Two QoS profiles are compatible if the a publisher and subcription
- * using their QoS policies can communicate with each other.
+ * Two QoS profiles are compatible if a publisher and subcription
+ * using the QoS policies can communicate with each other.
+ *
+ * If any of the profile policies has the value "system default", then it may not be
+ * possible to determine the compatibilty.
+ * In this case, the output parameter `compatibility` is set to `RMW_QOS_COMPATIBILITY_WARNING`
+ * and `reason` is populated
+ *
+ * Profile policies must not have the value "unknown". This is considered an error, and the
+ * output parameter `compatiblity` is not set.
  *
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------
  * Allocates Memory   | No
- * Thread-Safe        | No
+ * Thread-Safe        | Yes
  * Uses Atomics       | No
- * Lock-Free          | No
+ * Lock-Free          | Yes
  *
  * \param[in] publisher_profile: The QoS profile used for a publisher.
  * \param[in] subscription_profile: The QoS profile used for a subscription.
- * \return `true` if the publisher and subscription profiles are compatible, `false` otherwise.
+ * \param[out] compatibility: `RMW_QOS_COMPATIBILITY_OK` if the QoS profiles are compatible, or
+ *   `RMW_QOS_COMPATIBILITY_WARNING` if the QoS profiles might be compatible, or
+ *   `RMW_QOS_COMPATIBILITY_ERROR` if the QoS profiles are not compatible.
+ * \param[out] reason: A detailed reason for a QoS incompatibility.
+ *   Must be pre-allocated by the caller. This parameter is optional and may be set to `NULL`.
+ * \param[in] reason_size: Size of the string buffer `reason`, if one is provided.
+ * \return `RMW_RET_OK` if the check was successful, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if any of the policies have value "unknown"
  */
 RMW_PUBLIC
 RMW_WARN_UNUSED
-bool
-rmw_qos_profile_are_compatible(
+rmw_ret_t
+rmw_qos_profile_check_compatible(
   const rmw_qos_profile_t publisher_profile,
-  const rmw_qos_profile_t subscription_profile);
+  const rmw_qos_profile_t subscription_profile,
+  rmw_qos_compatibility_type_t * compatibility,
+  char * reason,
+  size_t reason_size);
 
 #ifdef __cplusplus
 }

--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -136,9 +136,9 @@ typedef enum RMW_PUBLIC_TYPE rmw_qos_compatibility_type_t
  * In this case, the output parameter `compatibility` is set to `RMW_QOS_COMPATIBILITY_WARNING`
  * and `reason` is populated.
  *
- * Profile policies must not have the value "unknown". An "unknown" value is considered an error
- * and `RMW_RET_INVALID_ARGUMENT` is returned.
- * `reason` will be set, identifying the offending policy.
+ * Profile policies must not have the value "unknown".
+ * An "unknown" value is considered an error and `RMW_RET_INVALID_ARGUMENT` is returned.
+ * `compatibility` and `reason` will not be set.
  *
  * If there is a compatibility warning or error, and a buffer is provided for `reason`, then an
  * explanation of all warnings and errors will be populated into the buffer, separated by

--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -146,7 +146,7 @@ typedef enum RMW_PUBLIC_TYPE rmw_qos_compatibility_type_t
  * Errors will appear before warnings in the string buffer.
  * If the provided buffer is not large enough, this function will still write to the buffer, up to
  * the `reason_size` number of characters.
- * Therefore, it is possible that not errors and warnings are communicated if the buffer size limit
+ * Therefore, it is possible that not all errors and warnings are communicated if the buffer size limit
  * is reached.
  * A buffer size of 2048 should be more than enough to capture all possible errors and warnings.
  *

--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -163,11 +163,15 @@ typedef enum RMW_PUBLIC_TYPE rmw_qos_compatibility_type_t
  * \param[out] compatibility: `RMW_QOS_COMPATIBILITY_OK` if the QoS profiles are compatible, or
  *   `RMW_QOS_COMPATIBILITY_WARNING` if the QoS profiles might be compatible, or
  *   `RMW_QOS_COMPATIBILITY_ERROR` if the QoS profiles are not compatible.
- * \param[out] reason: A detailed reason for a QoS incompatibility.
- *   Must be pre-allocated by the caller. This parameter is optional and may be set to `NULL`.
+ * \param[out] reason: A detailed reason for a QoS incompatibility or potential incompatibility.
+ *   Must be pre-allocated by the caller.
+ *   This parameter is optional and may be set to `NULL` if the reason information is not
+ *   desired.
  * \param[in] reason_size: Size of the string buffer `reason`, if one is provided.
+ *   If `reason` is `nullptr`, then this parameter must be zero.
  * \return `RMW_RET_OK` if the check was successful, or
- * \return `RMW_RET_INVALID_ARGUMENT` if `compatiblity` is NULL, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `compatiblity` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `reason` is `NULL` and  `reason_size` is not zero, or
  * \return `RMW_RET_INVALID_ARGUMENT` if any of the policies have value "unknown".
  * \return `RMW_RET_ERROR` if there is an unexpected error.
  */

--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -113,6 +113,30 @@ static const rmw_qos_profile_t rmw_qos_profile_unknown =
   false
 };
 
+/// Check if two QoS profiles are compatible.
+/**
+ * Two QoS profiles are compatible if the a publisher and subcription
+ * using their QoS policies can communicate with each other.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | No
+ *
+ * \param[in] publisher_profile: The QoS profile used for a publisher.
+ * \param[in] subscription_profile: The QoS profile used for a subscription.
+ * \return `true` if the publisher and subscription profiles are compatible, `false` otherwise.
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+bool
+rmw_qos_profile_are_compatible(
+  const rmw_qos_profile_t publisher_profile,
+  const rmw_qos_profile_t subscription_profile);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -131,14 +131,10 @@ typedef enum RMW_PUBLIC_TYPE rmw_qos_compatibility_type_t
  * Two QoS profiles are compatible if a publisher and subcription
  * using the QoS policies can communicate with each other.
  *
- * If any of the profile policies has the value "system default", then it may not be
+ * If any of the profile policies has the value "system default" or "unknown", then it may not be
  * possible to determine the compatibilty.
  * In this case, the output parameter `compatibility` is set to `RMW_QOS_COMPATIBILITY_WARNING`
  * and `reason` is populated.
- *
- * Profile policies must not have the value "unknown".
- * An "unknown" value is considered an error and `RMW_RET_INVALID_ARGUMENT` is returned.
- * `compatibility` and `reason` will not be set.
  *
  * If there is a compatibility warning or error, and a buffer is provided for `reason`, then an
  * explanation of all warnings and errors will be populated into the buffer, separated by
@@ -172,7 +168,6 @@ typedef enum RMW_PUBLIC_TYPE rmw_qos_compatibility_type_t
  * \return `RMW_RET_OK` if the check was successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `compatiblity` is `nullptr`, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `reason` is `NULL` and  `reason_size` is not zero, or
- * \return `RMW_RET_INVALID_ARGUMENT` if any of the policies have value "unknown".
  * \return `RMW_RET_ERROR` if there is an unexpected error.
  */
 RMW_PUBLIC

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -40,6 +40,9 @@
  * - A function to validate a node's name
  *   - rmw_validate_node_name()
  *   - rmw/validate_node_name.h
+ * - A function to validate the compatibility of two QoS profiles
+ *   - rmw_qos_profile_are_compatible()
+ *   - rmw/qos_profiles.h
  *
  * It also has some machinery that is necessary to wait on and act on these concepts:
  *

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -41,7 +41,7 @@
  *   - rmw_validate_node_name()
  *   - rmw/validate_node_name.h
  * - A function to validate the compatibility of two QoS profiles
- *   - rmw_qos_profile_are_compatible()
+ *   - rmw_qos_profile_check_compatible()
  *   - rmw/qos_profiles.h
  *
  * It also has some machinery that is necessary to wait on and act on these concepts:


### PR DESCRIPTION
Currently, users who are creating a publisher or subscription can receive 'QoS incompatibility'
events from the RMW if an incompatible endpoint is discovered. While this is useful, we
currently don't have a nice way for application to generally check if two QoS profiles are
compatible. For example, it would be nice if tooling could query the communication graph and
report any detected QoS incompatibilities.

In order to reduce code duplication, I think an API for checking QoS compatibilty should live
in a common place. I've opted for `rmw` (over a place like `rcl`) since it's possible QoS
compatiblity rules may vary per RMW vendor. Since rules for all DDS implementations should be
the same, we could put that common logic in `rmw_dds_common`.

---

The motivation for this API is to add features to tooling like [rqt_graph](https://github.com/ros-visualization/rqt_graph) and [ros2doctor](https://github.com/ros2/ros2cli/tree/f3a15e4b8f71336c03e56bbbf954ea87097459a0/ros2doctor) to help diagnose QoS compatibility issues. E.g. it would be useful to change how incompatible links in the ROS graph are rendered in `rqt_graph`.

---

Connected PRs:

- rmw_dds_common (implementation): https://github.com/ros2/rmw_dds_common/pull/45
- rmw_cyclonedds: https://github.com/ros2/rmw_cyclonedds/pull/286
- rmw_fastrtps: https://github.com/ros2/rmw_fastrtps/pull/511
- rmw_connext: https://github.com/ros2/rmw_connext/pull/488
- rmw_implementation: https://github.com/ros2/rmw_implementation/pull/180
- rmw_connextdds: TODO

CI for connected PRs listed above:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13736)](http://ci.ros2.org/job/ci_linux/13736/)
* Linux-aarch64 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8606)](https://ci.ros2.org/job/ci_linux-aarch64/8606/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11447)](http://ci.ros2.org/job/ci_osx/11447/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13810)](http://ci.ros2.org/job/ci_windows/13810/)