### PR TITLE
Shorten some excessively long lines of CMake

### DIFF
--- a/rmw_implementation_cmake/cmake/get_default_rmw_implementation.cmake
+++ b/rmw_implementation_cmake/cmake/get_default_rmw_implementation.cmake
@@ -57,7 +57,9 @@ macro(get_default_rmw_implementation var)
   list(FIND _middleware_implementations "${_middleware_implementation}" _index)
   if(_index EQUAL -1)
     string(REPLACE ";" ", " _middleware_implementations_string "${_middleware_implementations}")
-    message(FATAL_ERROR "Could not find ROS middleware implementation '${_middleware_implementation}'. Choose one of the following: ${_middleware_implementations_string}")
+    message(FATAL_ERROR
+      "Could not find ROS middleware implementation '${_middleware_implementation}'. "
+      "Choose one of the following: ${_middleware_implementations_string}")
   endif()
   find_package("${_middleware_implementation}" REQUIRED)
 


### PR DESCRIPTION
The line length enforcement in ament_lint_cmake has been broken for some time, but will be fixed by ament/ament_lint#236. This change brings this package into compliance with a 120 column limit.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13645)](http://ci.ros2.org/job/ci_linux/13645/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8525)](http://ci.ros2.org/job/ci_linux-aarch64/8525/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11360)](http://ci.ros2.org/job/ci_osx/11360/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13709)](http://ci.ros2.org/job/ci_windows/13709/)