### PR TITLE
Fix up errors in doxygen documentation.

### DIFF
--- a/rmw/include/rmw/allocators.h
+++ b/rmw/include/rmw/allocators.h
@@ -34,7 +34,7 @@ rmw_allocate(size_t size);
 
 /// Free memory using rcutils default allocator's deallocate()
 /**
- * \param[in] size pointer to allocated memory
+ * \param[in] pointer pointer to allocated memory
  */
 RMW_PUBLIC
 void
@@ -50,7 +50,7 @@ rmw_node_allocate(void);
 
 /// Free memory allocated to this node pointer using rcutils default allocator's deallocate()
 /**
- * \param[in] pointer to allocated memory
+ * \param[in] node pointer to allocated memory
  */
 RMW_PUBLIC
 void
@@ -66,7 +66,7 @@ rmw_publisher_allocate(void);
 
 /// Free memory using rcutils default allocator's deallocate()
 /**
- * \param[in] size pointer to allocated memory
+ * \param[in] publisher pointer to allocated memory
  */
 RMW_PUBLIC
 void
@@ -82,7 +82,7 @@ rmw_subscription_allocate(void);
 
 /// Free memory using rcutils default allocator's deallocate()
 /**
- * \param[in] size pointer to allocated memory
+ * \param[in] subscription pointer to allocated memory
  */
 RMW_PUBLIC
 void
@@ -98,7 +98,7 @@ rmw_guard_condition_allocate(void);
 
 /// Free memory using rcutils default allocator's deallocate()
 /**
- * \param[in] size pointer to allocated memory
+ * \param[in] guard_condition pointer to allocated memory
  */
 RMW_PUBLIC
 void
@@ -114,7 +114,7 @@ rmw_client_allocate(void);
 
 /// Free memory using rcutils default allocator's deallocate()
 /**
- * \param[in] size pointer to allocated memory
+ * \param[in] client pointer to allocated memory
  */
 RMW_PUBLIC
 void
@@ -130,7 +130,7 @@ rmw_service_allocate(void);
 
 /// Free memory using rcutils default allocator's deallocate()
 /**
- * \param[in] size pointer to allocated memory
+ * \param[in] service pointer to allocated memory
  */
 RMW_PUBLIC
 void
@@ -146,7 +146,7 @@ rmw_wait_set_allocate(void);
 
 /// Free memory using rcutils default allocator's deallocate()
 /**
- * \param[in] size pointer to allocated memory
+ * \param[in] wait_set pointer to allocated memory
  */
 RMW_PUBLIC
 void

--- a/rmw/include/rmw/event.h
+++ b/rmw/include/rmw/event.h
@@ -66,9 +66,9 @@ rmw_get_zero_initialized_event(void);
 
 /// Initialize a rmw publisher event.
 /**
- * \param[in|out] rmw_event to initialize
+ * \param[inout] rmw_event to initialize
  * \param[in] publisher to initialize with
- * \param[in|out] event_type for the event to initialize
+ * \param[inout] event_type for the event to initialize
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if invalid argument, or
  * \return `RMW_RET_UNSUPPORTED` if event_type is not supported, or
@@ -84,9 +84,9 @@ rmw_publisher_event_init(
 
 /// Initialize a rmw subscription event.
 /**
- * \param[in|out] rmw_event to initialize
+ * \param[inout] rmw_event to initialize
  * \param[in] subscription to initialize with
- * \param[in|out] event_type for the event to handle
+ * \param[inout] event_type for the event to handle
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if invalid argument, or
  * \return `RMW_RET_UNSUPPORTED` if event_type is not supported, or
@@ -103,7 +103,7 @@ rmw_subscription_event_init(
 /// Take an event from the event handle.
 /**
  * \param[in] event_handle event object to take from
- * \param[in|out] event_info event info object to write taken data into
+ * \param[inout] event_info event info object to write taken data into
  * \param[out] taken boolean flag indicating if an event was taken or not
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_BAD_ALLOC` if memory allocation failed, or

--- a/rmw/include/rmw/get_node_info_and_types.h
+++ b/rmw/include/rmw/get_node_info_and_types.h
@@ -138,7 +138,7 @@ rmw_get_subscriber_names_and_types_by_node(
  * \pre Given `topic_names_and_types` must be a zero-initialized array of names and types,
  *   as returned by rmw_get_zero_initialized_names_and_types().
  *
- * \param[in] Local node to query the ROS graph.
+ * \param[in] node Local node to query the ROS graph.
  * \param[in] allocator Allocator to be used when populating the `topic_names_and_types` array.
  * \param[in] node_name Name of the remote node to get information for.
  * \param[in] node_namespace Namespace of the remote node to get information for.
@@ -210,9 +210,9 @@ rmw_get_publisher_names_and_types_by_node(
  *     Check your allocator documentation for further reference.
  *
  * \param[in] node Local node to query the ROS graph.
+ * \param[in] allocator Allocator to be used when populating the `service_names_and_types` array.
  * \param[in] node_name Name of the remote node to get information for.
  * \param[in] node_namespace Namespace of the remote node to get information for.
- * \param[in] no_demangle Whether to demangle all topic names following ROS conventions or not.
  * \param[out] service_names_and_types Array of service names and types the remote node has
  *   created a service server for, populated on success but left unchanged on failure.
  *   If populated, it is up to the caller to finalize this array later on
@@ -279,9 +279,9 @@ rmw_get_service_names_and_types_by_node(
  *     Check your allocator documentation for further reference.
  *
  * \param[in] node Local node to query the ROS graph.
+ * \param[in] allocator Allocator to be used when populating the `service_names_and_types` array.
  * \param[in] node_name Name of the remote node to get information for.
  * \param[in] node_namespace Namespace of the remote node to get information for.
- * \param[in] no_demangle Whether to demangle all topic names following ROS conventions or not.
  * \param[out] service_names_and_types Array of service names and types the remote node has
  *   created a service client for, populated on success but left unchanged on failure.
  *   If populated, it is up to the caller to finalize this array later on

--- a/rmw/include/rmw/get_topic_endpoint_info.h
+++ b/rmw/include/rmw/get_topic_endpoint_info.h
@@ -151,7 +151,7 @@ rmw_get_publishers_info_by_topic(
  * \param[in] topic_name Name of the topic for subscription lookup, often a fully qualified
  *   topic name but not necessarily (see rmw_create_subscription()).
  * \param[in] no_mangle Whether to mangle the topic name before subscription lookup or not.
- * \param[out] publishers_info Array of subscription information, populated on success,
+ * \param[out] subscriptions_info Array of subscription information, populated on success,
  *   left unchanged on failure.
  *   If populated, it is up to the caller to finalize this array later on,
  *   using rmw_topic_endpoint_info_array_fini().

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -745,7 +745,7 @@ rmw_publisher_get_actual_qos(
  *   one registered with `publisher` on creation.
  *
  * \param[in] publisher Publisher to be used to send message.
- * \param[in] ros_message Serialized ROS message to be sent.
+ * \param[in] serialized_message Serialized ROS message to be sent.
  * \param[in] allocation Pre-allocated memory to be used. May be NULL.
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `publisher` is NULL, or
@@ -767,7 +767,7 @@ rmw_publish_serialized_message(
  * Given a message definition and bounds, compute the serialized size.
  *
  * \param[in] type_support The type support of the message to compute.
- * \param[in] bounds Artifical bounds to use on unbounded fields.
+ * \param[in] message_bounds Artifical bounds to use on unbounded fields.
  * \param[out] size The computed size of the serialized message.
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if either argument is null, or
@@ -1001,7 +1001,7 @@ rmw_fini_subscription_allocation(
  * \param[in] topic_name Name of the topic to subscribe to, often a fully qualified
  *   topic name unless `qos_profile` is configured to avoid ROS namespace conventions
  *   i.e. to create a native topic subscription
- * \param[in] qos_profile QoS policies for this subscription
+ * \param[in] qos_policies QoS policies for this subscription
  * \param[in] subscription_options Options for configuring this subscription
  * \return rmw subscription handle, or `NULL` if there was an error
  */
@@ -1858,7 +1858,7 @@ rmw_return_loaned_message_from_subscription(
  * \param[in] service_name Name of the service to be used, often a fully qualified
  *   service name unless `qos_profile` is configured to avoid ROS namespace conventions
  *   i.e. to create a native service client.
- * \param[in] qos_profile QoS policies for this service client's connections.
+ * \param[in] qos_policies QoS policies for this service client's connections.
  * \return rmw service client handle, or `NULL` if there was an error.
  */
 RMW_PUBLIC
@@ -2041,8 +2041,8 @@ rmw_send_request(
  *   It will also be left unchanged if this function succeeds but `taken` is false.
  *
  * \param[in] client Service client to take response from.
- * \param[out] response_header Service response header to write to.
- * \param[out] ros_request Type erased ROS service response to write to.
+ * \param[out] request_header Service response header to write to.
+ * \param[out] ros_response Type erased ROS service response to write to.
  * \param[out] taken Boolean flag indicating if a ROS service response was taken or not.
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_BAD_ALLOC` if memory allocation fails, or
@@ -2272,7 +2272,7 @@ rmw_take_request(
  * \pre Given `ros_response` must be a valid service response, whose type matches the
  *   service type support registered with the `service` on creation.
  *
- * \param[in] client Service server to send a response with.
+ * \param[in] service Service server to send a response with.
  * \param[in] request_header Service response header, same as the one taken
  *   with the corresponding ROS service request.
  * \param[in] ros_response ROS service response to be sent.
@@ -2776,7 +2776,7 @@ rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t * gid);
  *
  * \param[in] gid1 First unique identifier to compare.
  * \param[in] gid2 Second unique identifier to compare.
- * \param[out] bool true if both gids are equal, false otherwise.
+ * \param[out] result true if both gids are equal, false otherwise.
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `gid1` or `gid2` is NULL, or
  * \return `RMW_RET_INCORRECT_RMW_IMPLEMENTATION` if the implementation

--- a/rmw/include/rmw/security_options.h
+++ b/rmw/include/rmw/security_options.h
@@ -70,7 +70,7 @@ rmw_security_options_copy(
  *
  * \param[in] security_root_path path to be set.
  * \param[in] allocator allocator used to allocate the new path.
- * \param[in|out] security_options security options to be set.
+ * \param[inout] security_options security options to be set.
  * \returns RMW_RET_BAD_ALLOC, or
  * \returns RMW_RET_OK
  */

--- a/rmw/include/rmw/serialized_message.h
+++ b/rmw/include/rmw/serialized_message.h
@@ -28,9 +28,9 @@ extern "C"
  * \brief Serialized message as a string of bytes.
  *
  * It includes (but it is not limited to) the following members:
- *   \i \c buffer the reference to internal storage, as a pointer
- *   \i \c buffer_length the size of stored contents, as an unsigned integer
- *   \i \c buffer_capacity the capacity of internal storage, as an unsigned integer
+ *   \e \c buffer the reference to internal storage, as a pointer
+ *   \e \c buffer_length the size of stored contents, as an unsigned integer
+ *   \e \c buffer_capacity the capacity of internal storage, as an unsigned integer
  */
 
 /* For now this is a simple aliasing from a serialized message to a uint8 array.
@@ -44,7 +44,7 @@ typedef rcutils_uint8_array_t rmw_serialized_message_t;
 
 /// Initialize a serialized message, zero initializing its contents.
 /**
- * \pre Given serialized message must have been zero initialized.
+ * Given serialized message must have been zero initialized.
  *
  * \param[inout] serialized_message a pointer to the serialized message to initialize
  * \param[in] message_capacity the size of the memory to allocate
@@ -59,7 +59,7 @@ typedef rcutils_uint8_array_t rmw_serialized_message_t;
 
 /// Finalize a serialized message.
 /**
- * \pre Given serialized message must have been initialized with `rmw_serialized_message_init()`.
+ * Given serialized message must have been initialized with `rmw_serialized_message_init()`.
  *
  * \remarks If serialized message is zero initialized, then `RMW_RET_INVALID_ARGUMENT` is returned.
  *

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -159,13 +159,6 @@ typedef struct RMW_PUBLIC_TYPE rmw_subscription_options_t
    * This setting is most often used when data should only be received from
    * remote nodes, especially to avoid "double delivery" when both intra- and
    * inter- process communication is taking place.
-   *
-   * \TODO(wjwwood): nail this down when participant mapping is sorted out.
-   *   See: https://github.com/ros2/design/pull/250
-   *
-   * The definition of local is somewhat vague at the moment.
-   * Right now it means local to the node, and that definition works best, but
-   * may become more complicated when/if participants map to a context instead.
    */
   bool ignore_local_publications;
 

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -159,6 +159,13 @@ typedef struct RMW_PUBLIC_TYPE rmw_subscription_options_t
    * This setting is most often used when data should only be received from
    * remote nodes, especially to avoid "double delivery" when both intra- and
    * inter- process communication is taking place.
+   *
+   * \todo(wjwwood): nail this down when participant mapping is sorted out.
+   *   See: https://github.com/ros2/design/pull/250
+   *
+   * The definition of local is somewhat vague at the moment.
+   * Right now it means local to the node, and that definition works best, but
+   * may become more complicated when/if participants map to a context instead.
    */
   bool ignore_local_publications;
 

--- a/rmw/include/rmw/validate_full_topic_name.h
+++ b/rmw/include/rmw/validate_full_topic_name.h
@@ -92,9 +92,16 @@ rmw_validate_full_topic_name(
 /// Deterimine if a given topic name is valid.
 /**
  * This is an overload with an extra parameter for the length of topic_name.
- * \param[in] topic_name_length The number of characters in topic_name.
  *
  * \sa rmw_validate_full_topic_name(const char *, int *, size_t *)
+ *
+ * \param[in] topic_name topic name to be validated
+ * \param[in] topic_name_length The number of characters in topic_name.
+ * \param[out] validation_result int in which the result of the check is stored
+ * \param[out] invalid_index size_t index of the input string where an error occurred
+ * \returns `RMW_RET_OK` on successfully running the check, or
+ * \returns `RMW_RET_INVALID_ARGUMENT` on invalid parameters, or
+ * \returns `RMW_RET_ERROR` when an unspecified error occurs.
  */
 RMW_PUBLIC
 RMW_WARN_UNUSED
@@ -105,7 +112,12 @@ rmw_validate_full_topic_name_with_size(
   int * validation_result,
   size_t * invalid_index);
 
-/// Return a validation result description, or NULL if unknown or RMW_TOPIC_VALID.
+/// Return a validation result description, or NULL if RMW_TOPIC_VALID.
+/**
+ * \param[in] validation_result the result of validation
+ * \returns `NULL` if the validation result is `RMW_TOPIC_VALID`, or
+ * \returns a string representing the validation result.
+ */
 RMW_PUBLIC
 RMW_WARN_UNUSED
 const char *

--- a/rmw/include/rmw/validate_namespace.h
+++ b/rmw/include/rmw/validate_namespace.h
@@ -100,11 +100,17 @@ rmw_validate_namespace(
 /// Deterimine if a given namespace is valid.
 /**
  * This is an overload with an extra parameter for the length of namespace_.
- * If a non RMW_RET_OK return value is returned, the RMW error message will be set
- *
- * \param[in] namespace_length The number of characters in namespace_.
+ * If a non RMW_RET_OK return value is returned, the RMW error message will be set.
  *
  * \sa rmw_validate_namespace(const char *, int *, size_t *)
+ *
+ * \param[in] namespace_ namespace to be validated
+ * \param[in] namespace_length The number of characters in namespace_.
+ * \param[out] validation_result int in which the result of the check is stored
+ * \param[out] invalid_index index of the input string where an error occurred
+ * \returns `RMW_RET_OK` on successfully running the check, or
+ * \returns `RMW_RET_INVALID_ARGUMENT` on invalid parameters, or
+ * \returns `RMW_RET_ERROR` when an unspecified error occurs.
  */
 RMW_PUBLIC
 RMW_WARN_UNUSED
@@ -115,7 +121,12 @@ rmw_validate_namespace_with_size(
   int * validation_result,
   size_t * invalid_index);
 
-/// Return a validation result description, or NULL if unknown or RMW_NAMESPACE_VALID.
+/// Return a validation result description, or NULL if RMW_NAMESPACE_VALID.
+/**
+ * \param[in] validation_result the result of validation
+ * \returns `NULL` if the validation result is `RMW_NAMESPACE_VALID`, or
+ * \returns a string representing the validation result.
+ */
 RMW_PUBLIC
 RMW_WARN_UNUSED
 const char *

--- a/rmw/include/rmw/validate_node_name.h
+++ b/rmw/include/rmw/validate_node_name.h
@@ -86,9 +86,16 @@ rmw_validate_node_name(
 /// Deterimine if a given node name is valid.
 /**
  * This is an overload with an extra parameter for the length of node_name.
- * \param[in] node_name_length The number of characters in node_name.
  *
  * \sa rmw_validate_node_name(const char *, int *, size_t *)
+ *
+ * \param[in] node_name node name to be validated
+ * \param[in] node_name_length The number of characters in node_name.
+ * \param[out] validation_result int in which the result of the check is stored
+ * \param[out] invalid_index size_t index of the input string where an error occurred
+ * \returns `RMW_RET_OK` on successfully running the check, or
+ * \returns `RMW_RET_INVALID_ARGUMENT` on invalid parameters, or
+ * \returns `RMW_RET_ERROR` when an unspecified error occurs.
  */
 RMW_PUBLIC
 RMW_WARN_UNUSED
@@ -99,7 +106,12 @@ rmw_validate_node_name_with_size(
   int * validation_result,
   size_t * invalid_index);
 
-/// Return a validation result description, or NULL if unknown or RMW_NODE_NAME_VALID.
+/// Return a validation result description, or NULL if RMW_NODE_NAME_VALID.
+/**
+ * \param[in] validation_result the result of validation
+ * \returns `NULL` if the validation result is `RMW_NODE_NAME_VALID`, or
+ * \returns a string representing the validation result.
+ */
 RMW_PUBLIC
 RMW_WARN_UNUSED
 const char *


### PR DESCRIPTION
While running the rosdoc2 tool against this repository, I
came across these documentation errors.  This PR fixes them
all up so that doxygen runs clean.  We still can't successfully
run rosdoc2 on this package due to one other error, but at
least this will get us ready once we figure that issue out.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>