### PR TITLE
Use FastDDS Sync as default DDS

### DIFF
--- a/rmw_implementation_cmake/cmake/get_default_rmw_implementation.cmake
+++ b/rmw_implementation_cmake/cmake/get_default_rmw_implementation.cmake
@@ -32,8 +32,8 @@ macro(get_default_rmw_implementation var)
   if("${RMW_IMPLEMENTATION}" STREQUAL "" AND
     "$ENV{RMW_IMPLEMENTATION}" STREQUAL ""
   )
-    # prefer CycloneDDS, otherwise first in alphabetical order
-    list(FIND _middleware_implementations "rmw_cyclonedds_cpp" _index)
+    # prefer FastDDS, otherwise first in alphabetical order
+    list(FIND _middleware_implementations "rmw_fastrtps_cpp" _index)
     if(NOT _index EQUAL -1)
       list(GET _middleware_implementations ${_index} _middleware_implementation)
     else()


### PR DESCRIPTION
Switching the default DDS to FastDDS Sync after the Technical Steering Committee's recent vote  ([results](https://docs.google.com/presentation/d/19WUgt57s8lBgV_aMFblvo_iwUujLuQVdusC_3DGZwI8/edit#slide=id.gfbb633fe5d_0_19)). You can find the full meeting minutes here: https://discourse.ros.org/t/ros-2-tsc-meeting-minutes-2021-11-18/23209.

This PR relies on https://github.com/ros2/rmw_fastrtps/pull/571.

FYI @JaimeMartin and @MiguelCompany.
