### PR TITLE
[Service introspection] add writer_guid to rmw_client_t

### DIFF
--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -236,6 +236,9 @@ typedef struct RMW_PUBLIC_TYPE rmw_client_s
 
   /// The name of this service as exposed to the ros graph
   const char * service_name;
+
+  /// The writer guid associated with this client
+  int8_t writer_guid[16];
 } rmw_client_t;
 
 /// Handle for an rmw guard condition


### PR DESCRIPTION
This PR is a prototype for the service introspection REP (https://github.com/ros-infrastructure/rep/pull/360) implementing the proposed single serialized message approach (https://github.com/ros-infrastructure/rep/pull/360#discussion_r902987531).

Currently there is no way to get the client's writer guid from the context of [`rcl_send_request`](https://github.com/ros2/rcl/blob/4eccc3cbe65f5b58981f22efaf612a65731cb2f0/rcl/src/rcl/client.c#L239) which is needed by the proposed service introspection feature to populate the [ServiceEventInfo `client_id`](https://github.com/ros2/rcl_interfaces/blob/e37d06aed0358f4d2b877c16222cf73258d535f0/rcl_interfaces/msg/ServiceEventInfo.msg#L10) field such that an unique identifier for a service event may be built.

Connects to https://github.com/ros2/ros2/issues/1285
