### PR TITLE
change RMW_GID_STORAGE_SIZE from 24 to 16

### DIFF
--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -37,9 +37,7 @@ extern "C"
 #include "rmw/time.h"
 #include "rmw/visibility_control.h"
 
-// 24 bytes is the most memory needed to represent the GID by any current
-// implementation. It may need to be increased in the future.
-#define RMW_GID_STORAGE_SIZE 24u
+#define RMW_GID_STORAGE_SIZE 16u
 
 /// Structure which encapsulates an rmw node
 typedef struct RMW_PUBLIC_TYPE rmw_node_s


### PR DESCRIPTION
`RMW_GID_STORAGE_SIZE` is `#define`'d to be 24 bytes long but the GUID is 16 bytes for all currently supported RMW implementations. The reason why it is 24 bytes long is likely due to the now-legacy `rmw_opensplice`. (Introduced in  https://github.com/ros2/rmw/commit/f45e4cef6d9e3e28a282b46abe40ce71bf4a0907 for the content filtering feature https://github.com/ros2/rmw/pull/35) 
 From my understanding the last 8 bytes are never checked outside of a few tests.
 
 
### ConnextDDS
- Implemented as 16 octects (http://community.rti.com/rti-doc/500/ndds.5.0.0/doc/html/api_cpp/structDDS__GUID__t.html)
- Internal impl truncates 24 to 16 

https://github.com/ros2/rmw_connextdds/blob/79b037561a9e8a719cab6fea2b128c600ccd7113/rmw_connextdds_common/src/common/rmw_impl.cpp#L2120-L2104

### CycloneDDS
- Uses 16 octets and truncates 24 to 16 

https://github.com/eclipse-cyclonedds/cyclonedds/blob/0e2cd3e303be2171dd0e4fc685cc5031f70b0f52/src/core/ddsc/include/dds/dds.h#L192-L184

https://github.com/ros2/rmw_cyclonedds/blob/35c63e2dc30b9f58e3aa4a41f428310aff0cef83/rmw_cyclonedds_cpp/src/rmw_node.cpp#L808-L800

### FastRTPS 
- `GUID_t` contains a prefix (12 bytes) and entity id (4 bytes) for a total of 16 bytes.

https://github.com/eProsima/Fast-DDS/blob/e9e933b7dc4d78d59f6cf714fadbde9c62a1119e/include/fastdds/rtps/common/Guid.h#L44-L42


Knocking `RMW_GID_STORAGE_SIZE` down to 16 bytes (which is standardized as 16 octets) would also make `rmw_gid_t` consistent with `rmw_request_id_t` which contains a 16 byte uuid. 

https://github.com/ros2/rmw/blob/2259c3f6f3de8c479a9d5c74cdcd03d0010413cd/rmw/include/rmw/types.h#L356-L363


Signed-off-by: Brian Chen <brian.chen@openrobotics.org>