### PR TITLE
make writer_guid uint8_t[] instead of int8_t[] for consistency with rmw_gid_t

### DIFF
--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -358,7 +358,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_wait_set_s
 typedef struct RMW_PUBLIC_TYPE rmw_request_id_s
 {
   /// The guid of the writer associated with this request
-  int8_t writer_guid[RMW_GID_STORAGE_SIZE];
+  uint8_t writer_guid[RMW_GID_STORAGE_SIZE];
 
   /// Sequence number of this service
   int64_t sequence_number;


### PR DESCRIPTION
This PR address another inconsistency I noticed with with gids in rmw, namely that `rmw_gid_t` is an `uint8_t` array and `rmw_request_id_t.writer_guid` is a `int8_t` array. Changing this would silence some `rcl` compilation warnings introduced by the service introspection feature (https://github.com/ros2/ros2/issues/1285). 

Reference:

https://github.com/ros2/rmw/blob/2259c3f6f3de8c479a9d5c74cdcd03d0010413cd/rmw/include/rmw/types.h#L356-L363

https://github.com/ros2/rmw/blob/2259c3f6f3de8c479a9d5c74cdcd03d0010413cd/rmw/include/rmw/types.h#L620-L627

I'm going to keep this PR as draft until I review the rmw implementations to check if any notable assumptions are made about the signedness of `writer_guid`, but I don't expect it to be an issue.


Signed-off-by: Brian Chen <brian.chen@openrobotics.org>