### PR TITLE
callback can be NULL to clear in Listener APIs.

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -3082,10 +3082,10 @@ rmw_set_log_severity(rmw_log_severity_t severity);
  * at any time.
  *
  * \param[in] subscription The subscription on which to set the callback
- * \param[in] callback The callback to be called when new messages arrive
+ * \param[in] callback The callback to be called when new messages arrive, can be NULL
  * \param[in] user_data Given to the callback when called later, may be NULL
  * \return `RMW_RET_OK` if successful, or
- * \return `RMW_RET_INVALID_ARGUMENT` if `subscription` or `callback` is NULL, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `subscription` is NULL, or
  * \return `RMW_RET_UNSUPPORTED` if the API is not implemented in the dds implementation
  */
 RMW_PUBLIC
@@ -3116,10 +3116,10 @@ rmw_subscription_set_on_new_message_callback(
  * at any time.
  *
  * \param[in] service The service on which to set the callback
- * \param[in] callback The callback to be called when new requests arrive
+ * \param[in] callback The callback to be called when new requests arrive, can be NULL
  * \param[in] user_data Given to the callback when called later, may be NULL
  * \return `RMW_RET_OK` if callback was set to the listener, or
- * \return `RMW_RET_INVALID_ARGUMENT` if `service` or `callback` is NULL, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `service` is NULL, or
  * \return `RMW_RET_UNSUPPORTED` if the API is not implemented in the dds implementation
  */
 RMW_PUBLIC
@@ -3150,10 +3150,10 @@ rmw_service_set_on_new_request_callback(
  * at any time.
  *
  * \param[in] client The client on which to set the callback
- * \param[in] callback The callback to be called when new responses arrive
+ * \param[in] callback The callback to be called when new responses arrive, can be NULL
  * \param[in] user_data Given to the callback when called later, may be NULL
  * \return `RMW_RET_OK` if callback was set to the listener, or
- * \return `RMW_RET_INVALID_ARGUMENT` if `client` or `callback` is NULL, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `client` is NULL, or
  * \return `RMW_RET_UNSUPPORTED` if the API is not implemented in the dds implementation
  */
 RMW_PUBLIC
@@ -3188,10 +3188,10 @@ rmw_client_set_on_new_response_callback(
  * at any time.
  *
  * \param[in] event The event on which to set the callback
- * \param[in] callback The callback to be called when new events occur
+ * \param[in] callback The callback to be called when new events occur, can be NULL
  * \param[in] user_data Given to the callback when called later, may be NULL
  * \return `RMW_RET_OK` if callback was set to the listener, or
- * \return `RMW_RET_INVALID_ARGUMENT` if `event` or `callback` is NULL, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `event` is NULL, or
  * \return `RMW_RET_UNSUPPORTED` if the API is not implemented in the dds implementation
  */
 RMW_PUBLIC

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -3082,7 +3082,8 @@ rmw_set_log_severity(rmw_log_severity_t severity);
  * at any time.
  *
  * \param[in] subscription The subscription on which to set the callback
- * \param[in] callback The callback to be called when new messages arrive, can be NULL
+ * \param[in] callback The callback to be called when new messages arrive,
+ *   can be NULL to clear the registered callback
  * \param[in] user_data Given to the callback when called later, may be NULL
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `subscription` is NULL, or
@@ -3116,7 +3117,8 @@ rmw_subscription_set_on_new_message_callback(
  * at any time.
  *
  * \param[in] service The service on which to set the callback
- * \param[in] callback The callback to be called when new requests arrive, can be NULL
+ * \param[in] callback The callback to be called when new requests arrive,
+ *   can be NULL to clear the registered callback
  * \param[in] user_data Given to the callback when called later, may be NULL
  * \return `RMW_RET_OK` if callback was set to the listener, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `service` is NULL, or
@@ -3150,7 +3152,8 @@ rmw_service_set_on_new_request_callback(
  * at any time.
  *
  * \param[in] client The client on which to set the callback
- * \param[in] callback The callback to be called when new responses arrive, can be NULL
+ * \param[in] callback The callback to be called when new responses arrive,
+ *   can be NULL to clear the registered callback
  * \param[in] user_data Given to the callback when called later, may be NULL
  * \return `RMW_RET_OK` if callback was set to the listener, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `client` is NULL, or
@@ -3188,7 +3191,8 @@ rmw_client_set_on_new_response_callback(
  * at any time.
  *
  * \param[in] event The event on which to set the callback
- * \param[in] callback The callback to be called when new events occur, can be NULL
+ * \param[in] callback The callback to be called when new events occur,
+ *   can be NULL to clear the registered callback
  * \param[in] user_data Given to the callback when called later, may be NULL
  * \return `RMW_RET_OK` if callback was set to the listener, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `event` is NULL, or


### PR DESCRIPTION
doc section adjustment aligned with current implementation. (came up in https://github.com/ros2/rclcpp/pull/2002.)

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>