### PR TITLE
Change the system default depth to 1.

### DIFF
--- a/rmw/include/rmw/qos_profiles.h
+++ b/rmw/include/rmw/qos_profiles.h
@@ -90,7 +90,7 @@ static const rmw_qos_profile_t rmw_qos_profile_parameter_events =
 static const rmw_qos_profile_t rmw_qos_profile_system_default =
 {
   RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT,
-  RMW_QOS_POLICY_DEPTH_SYSTEM_DEFAULT,
+  1,
   RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT,
   RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT,
   RMW_QOS_DEADLINE_DEFAULT,


### PR DESCRIPTION
This is what the RMWs were doing anyway, and setting it to a number here (and not an unknown of 0) means that we won't get warnings from the rclcpp and rclpy layers.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #341 