### PR TITLE
Reduce GID storage to 16 bytes.

### DIFF
--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -37,9 +37,11 @@ extern "C"
 #include "rmw/time.h"
 #include "rmw/visibility_control.h"
 
-// 24 bytes is the most memory needed to represent the GID by any current
-// implementation. It may need to be increased in the future.
-#define RMW_GID_STORAGE_SIZE 24u
+// We define the GID as 16 bytes (128 bits).  This should be enough to ensure
+// uniqueness amongst all entities in the system.  It is up to the individual
+// RMW implementations to fill that in, either from the underlying middleware
+// or from the RMW layer itself.
+#define RMW_GID_STORAGE_SIZE 16u
 
 /// Structure which encapsulates an rmw node
 typedef struct RMW_PUBLIC_TYPE rmw_node_s
@@ -356,7 +358,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_wait_set_s
 typedef struct RMW_PUBLIC_TYPE rmw_request_id_s
 {
   /// The guid of the writer associated with this request
-  int8_t writer_guid[16];
+  int8_t writer_guid[RMW_GID_STORAGE_SIZE];
 
   /// Sequence number of this service
   int64_t sequence_number;
@@ -622,7 +624,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_gid_s
   /// Name of the rmw implementation
   const char * implementation_identifier;
 
-  /// Bype data Gid value
+  /// Byte data Gid value
   uint8_t data[RMW_GID_STORAGE_SIZE];
 } rmw_gid_t;
 


### PR DESCRIPTION
That is, the size of an RMW GID should be defined by the RMW
layer and the RMW implementations should conform to it.  With
that said, 16 bytes is plenty (and happens to match the size
of a GUID in DDS, which is also 16 bytes).  So reduce this
to 16 bytes.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this is a rehash of #328, but I think we have sufficient evidence now that this always should have been 16 bytes.  This will also require a PR in rmw_dds_common, which is coming up next.