### PR TITLE
Fix rmw->rwm typo

### DIFF
--- a/rmw/src/validate_full_topic_name.c
+++ b/rmw/src/validate_full_topic_name.c
@@ -147,6 +147,6 @@ rmw_full_topic_name_validation_result_string(int validation_result)
     case RMW_TOPIC_INVALID_TOO_LONG:
       return "topic length should not exceed '" RMW_STRINGIFY(RMW_TOPIC_MAX_NAME_LENGTH) "'";
     default:
-      return "unknown result code for rwm topic name validation";
+      return "unknown result code for rmw topic name validation";
   }
 }

--- a/rmw/test/test_validate_full_topic_name.cpp
+++ b/rmw/test/test_validate_full_topic_name.cpp
@@ -34,7 +34,7 @@ TEST(test_validate_topic_name, invalid_parameters) {
 
   // Invalid validation result
   ASSERT_STREQ(
-    "unknown result code for rwm topic name validation",
+    "unknown result code for rmw topic name validation",
     rmw_full_topic_name_validation_result_string(-1));
   rmw_reset_error();
 }


### PR DESCRIPTION
It said RWM when it meant RMW. Funny that it was copy-pasted into a test