### PR TITLE
Add type hash to rmw_topic_endpoint_info_t (rep2011)

### DIFF
--- a/rmw/include/rmw/topic_endpoint_info.h
+++ b/rmw/include/rmw/topic_endpoint_info.h
@@ -21,7 +21,6 @@ extern "C"
 #endif
 
 #include "rcutils/allocator.h"
-#include "rcutils/sha256.h"
 #include "rosidl_runtime_c/type_hash.h"
 #include "rmw/types.h"
 #include "rmw/visibility_control.h"
@@ -156,10 +155,7 @@ rmw_topic_endpoint_info_set_topic_type(
  *   - Access to the topic endpoint info data structure is not synchronized.
  *     It is not safe to read or write the `topic_type_hash` member of the given `topic_endpoint`
  *     while setting it.
- *   - Access to C-style string arguments is read-only but it is not synchronized.
  *     Concurrent `topic_type_hash` reads are safe, but concurrent reads and writes are not.
- *
- * \pre Given `topic_type_hash` is a valid uint8_t array of the correct size
  *
  * \param[inout] topic_endpoint_info Data structure to be populated.
  * \param[in] topic_type_hash Topic type hash to be copied.

--- a/rmw/include/rmw/topic_endpoint_info.h
+++ b/rmw/include/rmw/topic_endpoint_info.h
@@ -22,6 +22,7 @@ extern "C"
 
 #include "rcutils/allocator.h"
 #include "rcutils/sha256.h"
+#include "rosidl_runtime_c/type_hash.h"
 #include "rmw/types.h"
 #include "rmw/visibility_control.h"
 
@@ -34,10 +35,10 @@ typedef struct RMW_PUBLIC_TYPE rmw_topic_endpoint_info_s
   const char * node_name;
   /// Namespace of the node
   const char * node_namespace;
-  /// The associated topic type
+  /// The associated topic type's name
   const char * topic_type;
   /// Hashed value for topic type's description
-  uint8_t topic_type_hash[RCUTILS_SHA256_BLOCK_SIZE];
+  rosidl_type_hash_t topic_type_hash;
   /// The endpoint type
   rmw_endpoint_type_t endpoint_type;
   /// The GID of the endpoint
@@ -173,8 +174,7 @@ RMW_WARN_UNUSED
 rmw_ret_t
 rmw_topic_endpoint_info_set_topic_type_hash(
   rmw_topic_endpoint_info_t * topic_endpoint_info,
-  const uint8_t topic_type_hash[RCUTILS_SHA256_BLOCK_SIZE]);
-
+  const rosidl_type_hash_t * type_hash);
 
 /// Set the node name in the given topic endpoint info data structure.
 /**

--- a/rmw/include/rmw/topic_endpoint_info.h
+++ b/rmw/include/rmw/topic_endpoint_info.h
@@ -58,7 +58,7 @@ rmw_get_zero_initialized_topic_endpoint_info(void);
 
 /// Finalize a topic endpoint info data structure.
 /**
- * This function deallocates all allocated members of the given data structure,
+ * Deallocates all allocated members of the given data structure,
  * and then zero initializes it.
  * If a logical error, such as `RMW_RET_INVALID_ARGUMENT`, ensues, this function
  * will return early, leaving the given data structure unchanged.
@@ -97,8 +97,8 @@ rmw_topic_endpoint_info_fini(
 
 /// Set the topic type in the given topic endpoint info data structure.
 /**
- * This functions allocates memory and copies the value of the `topic_type`
- * argument to set the data structure `topic_type` member.
+ * Allocates memory and copies the value of the `topic_type`
+ * argument to set the data structure's `topic_type` member.
  *
  * <hr>
  * Attribute          | Adherence
@@ -140,7 +140,8 @@ rmw_topic_endpoint_info_set_topic_type(
 
 /// Set the topic type hash in the given topic endpoint info data structure.
 /**
- * This functions copies value `topic_type_hash` into data structure `topic_type_hash` member.
+ * Assigns the value of the `topic_type_hash` argument to the data structure's
+ * `topic_type_hash` member.
  *
  * <hr>
  * Attribute          | Adherence
@@ -174,8 +175,8 @@ rmw_topic_endpoint_info_set_topic_type_hash(
 
 /// Set the node name in the given topic endpoint info data structure.
 /**
- * This functions allocates memory and copies the value of the `node_name`
- * argument to set the data structure `node_name` member.
+ * Allocates memory and copies the value of the `node_name`
+ * argument to set the data structure's `node_name` member.
  *
  * <hr>
  * Attribute          | Adherence
@@ -217,8 +218,8 @@ rmw_topic_endpoint_info_set_node_name(
 
 /// Set the node namespace in the given topic endpoint info data structure.
 /**
- * This functions allocates memory and copies the value of the `node_namespace`
- * argument to set the data structure `node_namespace` member.
+ * Allocates memory and copies the value of the `node_namespace`
+ * argument to set the data structure's `node_namespace` member.
  *
  * <hr>
  * Attribute          | Adherence
@@ -260,7 +261,7 @@ rmw_topic_endpoint_info_set_node_namespace(
 
 /// Set the endpoint type in the given topic endpoint info data structure.
 /**
- * This functions assigns the value of the `type` argument to the data structure
+ * Assigns the value of the `type` argument to the data structure's
  * `endpoint_type` member.
  *
  * <hr>
@@ -293,7 +294,7 @@ rmw_topic_endpoint_info_set_endpoint_type(
 
 /// Set the endpoint gid in the given topic endpoint info data structure.
 /**
- * This functions copies the value of the `gid` argument to the data structure
+ * Copies the value of the `gid` argument to the data structure's
  * `endpoint_gid` member.
  *
  * <hr>
@@ -330,7 +331,7 @@ rmw_topic_endpoint_info_set_gid(
 
 /// Set the endpoint QoS profile in the given topic endpoint info data structure.
 /**
- * This functions assigns the value of the `qos_profile` argument to the data structure
+ * Assigns the value of the `qos_profile` argument to the data structure's
  * `qos_profile` member.
  *
  * <hr>

--- a/rmw/include/rmw/topic_endpoint_info.h
+++ b/rmw/include/rmw/topic_endpoint_info.h
@@ -21,6 +21,7 @@ extern "C"
 #endif
 
 #include "rcutils/allocator.h"
+#include "rcutils/sha256.h"
 #include "rmw/types.h"
 #include "rmw/visibility_control.h"
 
@@ -35,6 +36,8 @@ typedef struct RMW_PUBLIC_TYPE rmw_topic_endpoint_info_s
   const char * node_namespace;
   /// The associated topic type
   const char * topic_type;
+  /// Hashed value for topic type's description
+  uint8_t topic_type_hash[RCUTILS_SHA256_BLOCK_SIZE];
   /// The endpoint type
   rmw_endpoint_type_t endpoint_type;
   /// The GID of the endpoint
@@ -134,6 +137,44 @@ rmw_topic_endpoint_info_set_topic_type(
   rmw_topic_endpoint_info_t * topic_endpoint_info,
   const char * topic_type,
   rcutils_allocator_t * allocator);
+
+/// Set the topic type hash in the given topic endpoint info data structure.
+/**
+ * This functions copies value `topic_type_hash` into data structure `topic_type_hash` member.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \par Thread-safety
+ *   Setting a member is a reentrant procedure, but:
+ *   - Access to the topic endpoint info data structure is not synchronized.
+ *     It is not safe to read or write the `topic_type_hash` member of the given `topic_endpoint`
+ *     while setting it.
+ *   - Access to C-style string arguments is read-only but it is not synchronized.
+ *     Concurrent `topic_type_hash` reads are safe, but concurrent reads and writes are not.
+ *
+ * \pre Given `topic_type_hash` is a valid uint8_t array of the correct size
+ *
+ * \param[inout] topic_endpoint_info Data structure to be populated.
+ * \param[in] topic_type_hash Topic type hash to be copied.
+ * \returns `RMW_RET_OK` if successful, or
+ * \returns `RMW_RET_INVALID_ARGUMENT` if `topic_endpoint_info` is NULL, or
+ * \returns `RMW_RET_INVALID_ARGUMENT` if `topic_type_hash` is NULL, or
+ * \returns `RMW_RET_ERROR` when an unspecified error occurs.
+ * \remark This function sets the RMW error state on failure.
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_topic_endpoint_info_set_topic_type_hash(
+  rmw_topic_endpoint_info_t * topic_endpoint_info,
+  const uint8_t topic_type_hash[RCUTILS_SHA256_BLOCK_SIZE]);
+
 
 /// Set the node name in the given topic endpoint info data structure.
 /**

--- a/rmw/src/topic_endpoint_info.c
+++ b/rmw/src/topic_endpoint_info.c
@@ -150,6 +150,18 @@ rmw_topic_endpoint_info_set_topic_type(
 }
 
 rmw_ret_t
+rmw_topic_endpoint_info_set_topic_type_hash(
+  rmw_topic_endpoint_info_t * topic_endpoint_info,
+  const uint8_t topic_type_hash[RCUTILS_SHA256_BLOCK_SIZE])
+{
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RMW_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(topic_endpoint_info, RMW_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(topic_type_hash, RMW_RET_INVALID_ARGUMENT);
+  memcpy(topic_endpoint_info->topic_type_hash, topic_type_hash, RCUTILS_SHA256_BLOCK_SIZE);
+  return RMW_RET_OK;
+}
+
+rmw_ret_t
 rmw_topic_endpoint_info_set_node_name(
   rmw_topic_endpoint_info_t * topic_endpoint_info,
   const char * node_name,

--- a/rmw/src/topic_endpoint_info.c
+++ b/rmw/src/topic_endpoint_info.c
@@ -152,12 +152,12 @@ rmw_topic_endpoint_info_set_topic_type(
 rmw_ret_t
 rmw_topic_endpoint_info_set_topic_type_hash(
   rmw_topic_endpoint_info_t * topic_endpoint_info,
-  const uint8_t topic_type_hash[RCUTILS_SHA256_BLOCK_SIZE])
+  const rosidl_type_hash_t * type_hash)
 {
   RCUTILS_CAN_RETURN_WITH_ERROR_OF(RMW_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(topic_endpoint_info, RMW_RET_INVALID_ARGUMENT);
-  RCUTILS_CHECK_ARGUMENT_FOR_NULL(topic_type_hash, RMW_RET_INVALID_ARGUMENT);
-  memcpy(topic_endpoint_info->topic_type_hash, topic_type_hash, RCUTILS_SHA256_BLOCK_SIZE);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(type_hash, RMW_RET_INVALID_ARGUMENT);
+  topic_endpoint_info->topic_type_hash = *type_hash;
   return RMW_RET_OK;
 }
 

--- a/rmw/test/test_topic_endpoint_info.cpp
+++ b/rmw/test/test_topic_endpoint_info.cpp
@@ -58,6 +58,32 @@ TEST(test_topic_endpoint_info, set_topic_type) {
     "test_topic_type") << "Topic Type value is not as expected";
 }
 
+TEST(test_topic_endpoint_info, set_topic_type_hash) {
+  rmw_topic_endpoint_info_t topic_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
+  rosidl_type_hash_t type_hash = rosidl_get_zero_initialized_type_hash();
+  type_hash.version = 22;
+  for (size_t i = 0; i < ROSIDL_TYPE_HASH_SIZE; i++) {
+    type_hash.value[i] = i;
+  }
+
+  rmw_ret_t ret = rmw_topic_endpoint_info_set_topic_type_hash(nullptr, &type_hash);
+  EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) <<
+    "Expected invalid argument for null topic_endpoint_info";
+  rmw_reset_error();
+
+  ret = rmw_topic_endpoint_info_set_topic_type_hash(&topic_endpoint_info, nullptr);
+  EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << "Expected invalid argument for null type_hash";
+  rmw_reset_error();
+
+  ret = rmw_topic_endpoint_info_set_topic_type_hash(&topic_endpoint_info, &type_hash);
+  EXPECT_EQ(ret, RMW_RET_OK) << "Expected OK for valid arguments";
+
+  EXPECT_EQ(topic_endpoint_info.topic_type_hash.version, 22);
+  for (size_t i = 0; i < ROSIDL_TYPE_HASH_SIZE; i++) {
+    EXPECT_EQ(i, topic_endpoint_info.topic_type_hash.value[i]);
+  }
+}
+
 TEST(test_topic_endpoint_info, set_node_name) {
   rmw_topic_endpoint_info_t topic_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
   rcutils_allocator_t allocator = rcutils_get_default_allocator();

--- a/rmw/test/test_topic_endpoint_info.cpp
+++ b/rmw/test/test_topic_endpoint_info.cpp
@@ -62,7 +62,7 @@ TEST(test_topic_endpoint_info, set_topic_type_hash) {
   rmw_topic_endpoint_info_t topic_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
   rosidl_type_hash_t type_hash = rosidl_get_zero_initialized_type_hash();
   type_hash.version = 22;
-  for (size_t i = 0; i < ROSIDL_TYPE_HASH_SIZE; i++) {
+  for (uint8_t i = 0; i < ROSIDL_TYPE_HASH_SIZE; i++) {
     type_hash.value[i] = i;
   }
 


### PR DESCRIPTION
Part of ros2/ros2#1159
Depends on ros2/rosidl#722

Adds `topic_type_hash` field to `rmw_topic_endpoint_info_t` so that it can be filled by RMW implementations.