### PR TITLE
rmw_send_reqponse returns RMW_RET_TIMEOUT.

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -2425,6 +2425,7 @@ rmw_take_request(
  * \return `RMW_RET_INVALID_ARGUMENT` if `ros_response` is NULL, or
  * \return `RMW_RET_INCORRECT_RMW_IMPLEMENTATION` if the `service`
  *   implementation identifier does not match this implementation, or
+ * \return `RMW_RET_TIMEOUT` if a response reader is not ready yet, or
  * \return `RMW_RET_ERROR` if an unexpected error occurs.
  */
 RMW_PUBLIC


### PR DESCRIPTION
part of https://github.com/ros2/ros2/issues/1253, but not dependent.
this is doc fix for `rmw_send_response` to return `RMW_RET_TIMEOUT`.

- rmw_fastrtps

https://github.com/ros2/rmw_fastrtps/blob/926b3a1472fc5ba74972ca8384b054c94571b27c/rmw_fastrtps_shared_cpp/src/rmw_response.cpp#L148-L150

- rmw_cyclonedds

https://github.com/ros2/rmw_cyclonedds/blob/76572ebf1032f359ed302d7017471a295738fa1e/rmw_cyclonedds_cpp/src/rmw_node.cpp#L4541-L4542

- rmw_connnextdds does not return `RMW_RET_TIMEOUT`