### PR TITLE
definition of local means being in the same context.

### DIFF
--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -163,12 +163,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_subscription_options_s
    * remote nodes, especially to avoid "double delivery" when both intra- and
    * inter- process communication is taking place.
    *
-   * \todo(wjwwood): nail this down when participant mapping is sorted out.
-   *   See: https://github.com/ros2/design/pull/250
-   *
-   * The definition of local is somewhat vague at the moment.
-   * Right now it means local to the node, and that definition works best, but
-   * may become more complicated when/if participants map to a context instead.
+   * The definition of local means that in the same context.
    */
   bool ignore_local_publications;
 


### PR DESCRIPTION
Just a comment fix after https://github.com/ros2/design/pull/250.

Now `local` means by here is being in the same context. precisely with DDS-RTPS, GUID prefix matches.