### PR TITLE
Switch to target_link_libraries.

### DIFF
--- a/rmw/CMakeLists.txt
+++ b/rmw/CMakeLists.txt
@@ -55,18 +55,16 @@ add_library(${PROJECT_NAME} ${rmw_sources})
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rcutils::rcutils
   rosidl_dynamic_typesupport::rosidl_dynamic_typesupport
+  rosidl_runtime_c::rosidl_runtime_c
 )
 
 if(BUILD_TESTING AND NOT RCUTILS_DISABLE_FAULT_INJECTION)
   target_compile_definitions(${PROJECT_NAME} PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
 endif()
 
-ament_target_dependencies(${PROJECT_NAME}
-  "rcutils"
-  "rosidl_runtime_c"
-)
 configure_rmw_library(${PROJECT_NAME} LANGUAGE "C")
 
 ament_export_dependencies(

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -578,7 +578,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_qos_profile_s
   enum rmw_qos_durability_policy_e durability;
   /// The period at which messages are expected to be sent/received
   /**
-    * RMW_DURATION_UNSPEFICIED will use the RMW implementation's default value,
+    * RMW_DURATION_UNSPECIFIED will use the RMW implementation's default value,
     *   which may or may not be infinite.
     * RMW_DURATION_INFINITE explicitly states that messages never miss a deadline expectation.
     */


### PR DESCRIPTION
There is no need to use ament_target_dependencies here.