### PR TITLE
Removed warnings - strict-prototypes

### DIFF
--- a/rmw/include/rmw/security_options.h
+++ b/rmw/include/rmw/security_options.h
@@ -42,12 +42,12 @@ typedef struct RMW_PUBLIC_TYPE rmw_security_options_s
 /// Get zero initialized security options.
 RMW_PUBLIC
 rmw_security_options_t
-rmw_get_zero_initialized_security_options();
+rmw_get_zero_initialized_security_options(void);
 
 /// Get default initialized security options.
 RMW_PUBLIC
 rmw_security_options_t
-rmw_get_default_security_options();
+rmw_get_default_security_options(void);
 
 /// Copy the given security options.
 /**

--- a/rmw/include/rmw/subscription_content_filter_options.h
+++ b/rmw/include/rmw/subscription_content_filter_options.h
@@ -49,7 +49,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_subscription_content_filter_options_s
 /// Get zero initialized content filter options.
 RMW_PUBLIC
 rmw_subscription_content_filter_options_t
-rmw_get_zero_initialized_content_filter_options();
+rmw_get_zero_initialized_content_filter_options(void);
 
 
 /// Initialize the given content filter options.

--- a/rmw/src/allocators.c
+++ b/rmw/src/allocators.c
@@ -42,7 +42,7 @@ rmw_free(void * pointer)
 }
 
 rmw_node_t *
-rmw_node_allocate()
+rmw_node_allocate(void)
 {
   // Could be overridden with custom (maybe static) node struct allocator
   return (rmw_node_t *)rmw_allocate(sizeof(rmw_node_t));
@@ -56,7 +56,7 @@ rmw_node_free(rmw_node_t * node)
 }
 
 rmw_publisher_t *
-rmw_publisher_allocate()
+rmw_publisher_allocate(void)
 {
   // Could be overridden with custom (maybe static) publisher struct allocator
   return (rmw_publisher_t *)rmw_allocate(sizeof(rmw_publisher_t));
@@ -70,7 +70,7 @@ rmw_publisher_free(rmw_publisher_t * publisher)
 }
 
 rmw_subscription_t *
-rmw_subscription_allocate()
+rmw_subscription_allocate(void)
 {
   // Could be overridden with custom (maybe static) subscription struct allocator
   return (rmw_subscription_t *)rmw_allocate(sizeof(rmw_subscription_t));
@@ -84,7 +84,7 @@ rmw_subscription_free(rmw_subscription_t * subscription)
 }
 
 rmw_guard_condition_t *
-rmw_guard_condition_allocate()
+rmw_guard_condition_allocate(void)
 {
   // Could be overridden with custom (maybe static) guard_condition
   // struct allocator
@@ -99,7 +99,7 @@ rmw_guard_condition_free(rmw_guard_condition_t * guard_condition)
 }
 
 rmw_client_t *
-rmw_client_allocate()
+rmw_client_allocate(void)
 {
   // Could be overridden with custom (maybe static) client struct allocator
   return (rmw_client_t *)rmw_allocate(sizeof(rmw_client_t));
@@ -113,7 +113,7 @@ rmw_client_free(rmw_client_t * client)
 }
 
 rmw_service_t *
-rmw_service_allocate()
+rmw_service_allocate(void)
 {
   // Could be overridden with custom (maybe static) client struct allocator
   return (rmw_service_t *)rmw_allocate(sizeof(rmw_service_t));
@@ -127,7 +127,7 @@ rmw_service_free(rmw_service_t * service)
 }
 
 rmw_wait_set_t *
-rmw_wait_set_allocate()
+rmw_wait_set_allocate(void)
 {
   // Could be overridden with custom (maybe static) client struct allocator
   return (rmw_wait_set_t *)rmw_allocate(sizeof(rmw_wait_set_t));

--- a/rmw/src/security_options.c
+++ b/rmw/src/security_options.c
@@ -20,14 +20,14 @@
 #include "rmw/security_options.h"
 
 rmw_security_options_t
-rmw_get_zero_initialized_security_options()
+rmw_get_zero_initialized_security_options(void)
 {
   rmw_security_options_t zero_initialized_options = {0, NULL};
   return zero_initialized_options;
 }
 
 rmw_security_options_t
-rmw_get_default_security_options()
+rmw_get_default_security_options(void)
 {
   rmw_security_options_t default_options = {
     RMW_SECURITY_ENFORCEMENT_PERMISSIVE,

--- a/rmw/src/subscription_content_filter_options.c
+++ b/rmw/src/subscription_content_filter_options.c
@@ -20,7 +20,7 @@
 #include "rmw/subscription_content_filter_options.h"
 
 rmw_subscription_content_filter_options_t
-rmw_get_zero_initialized_content_filter_options()
+rmw_get_zero_initialized_content_filter_options(void)
 {
   return (const rmw_subscription_content_filter_options_t) {
            .filter_expression = NULL,


### PR DESCRIPTION
There are new warnings on CI related with this compiler option `strict-prototypes`

https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1860/gcc/new/