### PR TITLE
removed deprecated rmw_node_assert_liveliness()

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -199,17 +199,6 @@ RMW_WARN_UNUSED
 rmw_ret_t
 rmw_destroy_node(rmw_node_t * node);
 
-/**
- * \deprecated `rmw_node_assert_liveliness` implementation was removed.
- *   If manual liveliness assertion is needed, use MANUAL_BY_TOPIC.
- */
-RMW_PUBLIC
-RCUTILS_DEPRECATED_WITH_MSG(
-  "rmw_node_assert_liveliness implementation was removed."
-  " If manual liveliness assertion is needed, use MANUAL_BY_TOPIC.")
-rmw_ret_t
-rmw_node_assert_liveliness(const rmw_node_t * node);
-
 /// Return a guard condition which is triggered when the ROS graph changes.
 /**
  * The guard condition will be triggered anytime a change to the ROS graph occurs.


### PR DESCRIPTION
removed deprecated rmw_node_assert_liveliness() (since `jazzy`)