### PR TITLE
Fix typo with RMW_DURATION_UNSPECIFIED

### DIFF
--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -585,7 +585,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_qos_profile_s
   struct rmw_time_s deadline;
   /// The age at which messages are considered expired and no longer valid
   /**
-    * RMW_DURATION_UNSPEFICIED will use the RMW implementation's default value,
+    * RMW_DURATION_UNSPECIFIED will use the RMW implementation's default value,
     *   which may or may not be infinite.
     * RMW_DURATION_INFINITE explicitly states that messages do not expire.
     */
@@ -594,7 +594,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_qos_profile_s
   enum rmw_qos_liveliness_policy_e liveliness;
   /// The time within which the RMW node or publisher must show that it is alive
   /**
-    * RMW_DURATION_UNSPEFICIED will use the RMW implementation's default value,
+    * RMW_DURATION_UNSPECIFIED will use the RMW implementation's default value,
     *   which may or may not be infinite.
     * RMW_DURATION_INFINITE explicitly states that liveliness is not enforced.
     */


### PR DESCRIPTION
Defined here: https://github.com/ros2/rmw/blob/016875cb79e2c92b8d2a0ecc0fb773fe0c53cc4a/rmw/include/rmw/time.h#L55