### PR TITLE
add rmw_get_default_xxx to return the structure with default values.

### DIFF
--- a/rmw/include/rmw/event.h
+++ b/rmw/include/rmw/event.h
@@ -68,6 +68,12 @@ RMW_WARN_UNUSED
 rmw_event_t
 rmw_get_zero_initialized_event(void);
 
+/// Return a default event structure.
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_event_t
+rmw_get_default_event(void);
+
 /// Initialize a rmw publisher event.
 /**
  * \param[inout] rmw_event to initialize

--- a/rmw/include/rmw/init.h
+++ b/rmw/include/rmw/init.h
@@ -55,6 +55,12 @@ RMW_WARN_UNUSED
 rmw_context_t
 rmw_get_zero_initialized_context(void);
 
+/// Return a default context structure.
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_context_t
+rmw_get_default_context(void);
+
 /// Initialize the middleware with the given options, and yielding an context.
 /**
  * Context is filled with middleware specific data upon success of this function.

--- a/rmw/include/rmw/init_options.h
+++ b/rmw/include/rmw/init_options.h
@@ -71,6 +71,12 @@ RMW_WARN_UNUSED
 rmw_init_options_t
 rmw_get_zero_initialized_init_options(void);
 
+/// Return a default init options structure.
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_init_options_t
+rmw_get_default_init_options(void);
+
 /// Initialize given init options with the default values and implementation specific values.
 /**
  * The given allocator is used, if required, during setup of the init options,

--- a/rmw/src/event.c
+++ b/rmw/src/event.c
@@ -24,11 +24,15 @@ extern "C" {
 rmw_event_t
 rmw_get_zero_initialized_event(void)
 {
-  // TODO(@fujitatomoya): This is not exatly zero initialized structure.
-  /// We should introduce xxx_get_default_event to return the default values.
+  // All members are initialized to 0 or NULL by C99 6.7.8/10.
+  static const rmw_event_t event;
+  return event;
+}
+
+rmw_event_t
+rmw_get_default_event(void)
+{
   static const rmw_event_t event = {
-    .implementation_identifier = NULL,
-    .data = NULL,
     .event_type = RMW_EVENT_INVALID
   };
   return event;

--- a/rmw/src/init.c
+++ b/rmw/src/init.c
@@ -26,10 +26,18 @@ extern "C"
 rmw_context_t
 rmw_get_zero_initialized_context(void)
 {
+  // All members are initialized to 0 or NULL by C99 6.7.8/10.
+  static const rmw_context_t context;
+  return context;
+}
+
+rmw_context_t
+rmw_get_default_context(void)
+{
   return (const rmw_context_t) {
            .instance_id = 0,
            .implementation_identifier = NULL,
-           .options = rmw_get_zero_initialized_init_options(),
+           .options = rmw_get_default_init_options(),
            .actual_domain_id = 0u,
            .impl = NULL
   };  // NOLINT(readability/braces): false positive

--- a/rmw/src/init_options.c
+++ b/rmw/src/init_options.c
@@ -25,8 +25,14 @@ extern "C"
 rmw_init_options_t
 rmw_get_zero_initialized_init_options(void)
 {
-  // TODO(@fujitatomoya): This is not exatly zero initialized structure.
-  /// We should introduce xxx_get_default_init_optionst to return the default values.
+  // All members are initialized to 0 or NULL by C99 6.7.8/10.
+  static const rmw_init_options_t init_option;
+  return init_option;
+}
+
+rmw_init_options_t
+rmw_get_default_init_options(void)
+{
   static const rmw_init_options_t init_option = {
     .domain_id = RMW_DEFAULT_DOMAIN_ID,
     .discovery_options = {RMW_AUTOMATIC_DISCOVERY_RANGE_NOT_SET, 0},

--- a/rmw/test/test_event.cpp
+++ b/rmw/test/test_event.cpp
@@ -20,6 +20,14 @@ TEST(rmw_event, get_zero_initialized_event)
   const rmw_event_t actual = rmw_get_zero_initialized_event();
   EXPECT_EQ(nullptr, actual.implementation_identifier);
   EXPECT_EQ(nullptr, actual.data);
+  EXPECT_EQ(0u, actual.event_type);
+}
+
+TEST(rmw_event, get_default_event)
+{
+  const rmw_event_t actual = rmw_get_default_event();
+  EXPECT_EQ(nullptr, actual.implementation_identifier);
+  EXPECT_EQ(nullptr, actual.data);
   EXPECT_EQ(RMW_EVENT_INVALID, actual.event_type);
 }
 
@@ -36,5 +44,5 @@ TEST(rmw_event, event_fini)
   EXPECT_EQ(rmw_event_fini(&event), RMW_RET_OK);
   EXPECT_EQ(nullptr, event.implementation_identifier);
   EXPECT_EQ(nullptr, event.data);
-  EXPECT_EQ(RMW_EVENT_INVALID, event.event_type);
+  EXPECT_EQ(0u, event.event_type);
 }

--- a/rmw/test/test_init.cpp
+++ b/rmw/test/test_init.cpp
@@ -15,9 +15,22 @@
 #include "gmock/gmock.h"
 #include "rmw/init.h"
 
-TEST(rmw_init_options, get_zero_initialized_init_options)
+TEST(rmw_init_options, get_zero_initialized_context)
 {
   const rmw_context_t context = rmw_get_zero_initialized_context();
   EXPECT_EQ(context.instance_id, 0u);
+  EXPECT_EQ(context.implementation_identifier, nullptr);
+  EXPECT_EQ(context.options.domain_id, 0u);
+  EXPECT_EQ(context.actual_domain_id, 0u);
+  EXPECT_EQ(context.impl, nullptr);
+}
+
+TEST(rmw_init_options, get_default_context)
+{
+  const rmw_context_t context = rmw_get_default_context();
+  EXPECT_EQ(context.instance_id, 0u);
+  EXPECT_EQ(context.implementation_identifier, nullptr);
+  EXPECT_EQ(context.options.domain_id, RMW_DEFAULT_DOMAIN_ID);
+  EXPECT_EQ(context.actual_domain_id, 0u);
   EXPECT_EQ(context.impl, nullptr);
 }

--- a/rmw/test/test_init_options.cpp
+++ b/rmw/test/test_init_options.cpp
@@ -18,7 +18,19 @@
 TEST(rmw_init_options, get_zero_initialized_init_options)
 {
   const rmw_init_options_t options = rmw_get_zero_initialized_init_options();
+  EXPECT_EQ(options.domain_id, 0u);
   EXPECT_EQ(options.instance_id, 0u);
   EXPECT_EQ(options.implementation_identifier, nullptr);
   EXPECT_EQ(options.impl, nullptr);
+  EXPECT_EQ(options.enclave, nullptr);
+}
+
+TEST(rmw_init_options, get_default_init_options)
+{
+  const rmw_init_options_t options = rmw_get_default_init_options();
+  EXPECT_EQ(options.domain_id, RMW_DEFAULT_DOMAIN_ID);
+  EXPECT_EQ(options.instance_id, 0u);
+  EXPECT_EQ(options.implementation_identifier, nullptr);
+  EXPECT_EQ(options.impl, nullptr);
+  EXPECT_EQ(options.enclave, nullptr);
 }


### PR DESCRIPTION
follow up for https://github.com/ros2/rmw/pull/378

- rmw_get_zero_initialized_xxx should return zero initialized data structure without any default non-zero values. zero initialized data is mostly used for copying the data object (allocating destination data structure) and finalization.
- rmw_get_default_xxx should return the data structure with default values, so that application can use those default values to process the initialization.