### PR TITLE
get_zero_initialized_xxx functions return zero initialized structure.

### DIFF
--- a/rmw/include/rmw/event.h
+++ b/rmw/include/rmw/event.h
@@ -32,6 +32,9 @@ extern "C"
 /// Define publisher/subscription events
 typedef enum rmw_event_type_e
 {
+  // initial value
+  RMW_EVENT_INVALID,
+
   // subscription events
   RMW_EVENT_LIVELINESS_CHANGED,
   RMW_EVENT_REQUESTED_DEADLINE_MISSED,
@@ -48,7 +51,7 @@ typedef enum rmw_event_type_e
   RMW_EVENT_PUBLICATION_MATCHED,
 
   // sentinel value
-  RMW_EVENT_INVALID
+  RMW_EVENT_TYPE_MAX
 } rmw_event_type_t;
 
 /// Encapsulate the RMW event implementation, data, and type.

--- a/rmw/include/rmw/event.h
+++ b/rmw/include/rmw/event.h
@@ -32,8 +32,8 @@ extern "C"
 /// Define publisher/subscription events
 typedef enum rmw_event_type_e
 {
-  // initial value
-  RMW_EVENT_INVALID,
+  // must be zero or rmw_get_zero_initialized_event will break
+  RMW_EVENT_INVALID = 0,
 
   // subscription events
   RMW_EVENT_LIVELINESS_CHANGED,

--- a/rmw/src/event.c
+++ b/rmw/src/event.c
@@ -24,13 +24,8 @@ extern "C" {
 rmw_event_t
 rmw_get_zero_initialized_event(void)
 {
-  // TODO(@fujitatomoya): This is not exatly zero initialized structure.
-  /// We should introduce xxx_get_default_event to return the default values.
-  static const rmw_event_t event = {
-    .implementation_identifier = NULL,
-    .data = NULL,
-    .event_type = RMW_EVENT_INVALID
-  };
+  // All members are initialized to 0 or NULL by C99 6.7.8/10.
+  static const rmw_event_t event;
   return event;
 }
 

--- a/rmw/src/init.c
+++ b/rmw/src/init.c
@@ -26,13 +26,9 @@ extern "C"
 rmw_context_t
 rmw_get_zero_initialized_context(void)
 {
-  return (const rmw_context_t) {
-           .instance_id = 0,
-           .implementation_identifier = NULL,
-           .options = rmw_get_zero_initialized_init_options(),
-           .actual_domain_id = 0u,
-           .impl = NULL
-  };  // NOLINT(readability/braces): false positive
+  // All members are initialized to 0 or NULL by C99 6.7.8/10.
+  static const rmw_context_t context;
+  return context;
 }
 
 #ifdef __cplusplus

--- a/rmw/src/init_options.c
+++ b/rmw/src/init_options.c
@@ -25,17 +25,8 @@ extern "C"
 rmw_init_options_t
 rmw_get_zero_initialized_init_options(void)
 {
-  // TODO(@fujitatomoya): This is not exatly zero initialized structure.
-  /// We should introduce xxx_get_default_init_optionst to return the default values.
-  static const rmw_init_options_t init_option = {
-    .domain_id = RMW_DEFAULT_DOMAIN_ID,
-    .discovery_options = {RMW_AUTOMATIC_DISCOVERY_RANGE_NOT_SET, 0},
-    .implementation_identifier = NULL,
-    .impl = NULL,
-    .instance_id = 0,
-    .enclave = NULL,
-    .security_options = {RMW_SECURITY_ENFORCEMENT_PERMISSIVE, NULL},
-  };
+  // All members are initialized to 0 or NULL by C99 6.7.8/10.
+  static const rmw_init_options_t init_option;
   return init_option;
 }
 

--- a/rmw/test/test_event.cpp
+++ b/rmw/test/test_event.cpp
@@ -20,6 +20,7 @@ TEST(rmw_event, get_zero_initialized_event)
   const rmw_event_t actual = rmw_get_zero_initialized_event();
   EXPECT_EQ(nullptr, actual.implementation_identifier);
   EXPECT_EQ(nullptr, actual.data);
+  EXPECT_EQ(0, RMW_EVENT_INVALID);
   EXPECT_EQ(RMW_EVENT_INVALID, actual.event_type);
 }
 

--- a/rmw/test/test_event.cpp
+++ b/rmw/test/test_event.cpp
@@ -20,7 +20,7 @@ TEST(rmw_event, get_zero_initialized_event)
   const rmw_event_t actual = rmw_get_zero_initialized_event();
   EXPECT_EQ(nullptr, actual.implementation_identifier);
   EXPECT_EQ(nullptr, actual.data);
-  EXPECT_EQ(0u, actual.event_type);
+  EXPECT_EQ(RMW_EVENT_INVALID, actual.event_type);
 }
 
 TEST(rmw_event, event_fini)
@@ -36,5 +36,5 @@ TEST(rmw_event, event_fini)
   EXPECT_EQ(rmw_event_fini(&event), RMW_RET_OK);
   EXPECT_EQ(nullptr, event.implementation_identifier);
   EXPECT_EQ(nullptr, event.data);
-  EXPECT_EQ(0u, event.event_type);
+  EXPECT_EQ(RMW_EVENT_INVALID, event.event_type);
 }

--- a/rmw/test/test_event.cpp
+++ b/rmw/test/test_event.cpp
@@ -20,7 +20,7 @@ TEST(rmw_event, get_zero_initialized_event)
   const rmw_event_t actual = rmw_get_zero_initialized_event();
   EXPECT_EQ(nullptr, actual.implementation_identifier);
   EXPECT_EQ(nullptr, actual.data);
-  EXPECT_EQ(RMW_EVENT_INVALID, actual.event_type);
+  EXPECT_EQ(0u, actual.event_type);
 }
 
 TEST(rmw_event, event_fini)
@@ -36,5 +36,5 @@ TEST(rmw_event, event_fini)
   EXPECT_EQ(rmw_event_fini(&event), RMW_RET_OK);
   EXPECT_EQ(nullptr, event.implementation_identifier);
   EXPECT_EQ(nullptr, event.data);
-  EXPECT_EQ(RMW_EVENT_INVALID, event.event_type);
+  EXPECT_EQ(0u, event.event_type);
 }

--- a/rmw/test/test_init.cpp
+++ b/rmw/test/test_init.cpp
@@ -19,5 +19,7 @@ TEST(rmw_init_options, get_zero_initialized_init_options)
 {
   const rmw_context_t context = rmw_get_zero_initialized_context();
   EXPECT_EQ(context.instance_id, 0u);
+  EXPECT_EQ(context.implementation_identifier, nullptr);
+  EXPECT_EQ(context.actual_domain_id, 0u);
   EXPECT_EQ(context.impl, nullptr);
 }

--- a/rmw/test/test_init_options.cpp
+++ b/rmw/test/test_init_options.cpp
@@ -18,7 +18,9 @@
 TEST(rmw_init_options, get_zero_initialized_init_options)
 {
   const rmw_init_options_t options = rmw_get_zero_initialized_init_options();
+  EXPECT_EQ(options.domain_id, 0u);
   EXPECT_EQ(options.instance_id, 0u);
   EXPECT_EQ(options.implementation_identifier, nullptr);
   EXPECT_EQ(options.impl, nullptr);
+  EXPECT_EQ(options.enclave, nullptr);
 }

--- a/rmw/test/test_init_options.cpp
+++ b/rmw/test/test_init_options.cpp
@@ -23,4 +23,12 @@ TEST(rmw_init_options, get_zero_initialized_init_options)
   EXPECT_EQ(options.implementation_identifier, nullptr);
   EXPECT_EQ(options.impl, nullptr);
   EXPECT_EQ(options.enclave, nullptr);
+  EXPECT_EQ(
+    options.security_options.enforce_security,
+    RMW_SECURITY_ENFORCEMENT_PERMISSIVE);
+  EXPECT_EQ(
+    options.security_options.security_root_path, nullptr);
+  EXPECT_EQ(
+    options.discovery_options.automatic_discovery_range,
+    RMW_AUTOMATIC_DISCOVERY_RANGE_NOT_SET);
 }


### PR DESCRIPTION
replaces https://github.com/ros2/rmw/pull/379

and follow up https://github.com/ros2/rmw/pull/378

> [!IMPORTANT]  
> This needs to be merged with https://github.com/ros2/rmw_connextdds/pull/162, https://github.com/ros2/rmw_fastrtps/pull/785 and https://github.com/ros2/rmw_cyclonedds/pull/518