### PR TITLE
Fix rmw_validate_namespace{_with_size} error handling.

### DIFF
--- a/rmw/src/validate_namespace.c
+++ b/rmw/src/validate_namespace.c
@@ -29,9 +29,6 @@ rmw_validate_namespace(
   int * validation_result,
   size_t * invalid_index)
 {
-  if (!namespace_) {
-    return RMW_RET_INVALID_ARGUMENT;
-  }
   return rmw_validate_namespace_with_size(
     namespace_, strlen(namespace_), validation_result, invalid_index);
 }
@@ -43,12 +40,8 @@ rmw_validate_namespace_with_size(
   int * validation_result,
   size_t * invalid_index)
 {
-  if (!namespace_) {
-    return RMW_RET_INVALID_ARGUMENT;
-  }
-  if (!validation_result) {
-    return RMW_RET_INVALID_ARGUMENT;
-  }
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(namespace_, RMW_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(validation_result, RMW_RET_INVALID_ARGUMENT);
 
   // Special case for root namepsace
   if (namespace_length == 1 && namespace_[0] == '/') {

--- a/rmw/src/validate_namespace.c
+++ b/rmw/src/validate_namespace.c
@@ -29,6 +29,8 @@ rmw_validate_namespace(
   int * validation_result,
   size_t * invalid_index)
 {
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(namespace_, RMW_RET_INVALID_ARGUMENT);
+
   return rmw_validate_namespace_with_size(
     namespace_, strlen(namespace_), validation_result, invalid_index);
 }


### PR DESCRIPTION
It should always set an error, even on invalid arguments.