### PR TITLE
Fix ugly overwritten warning messages on error paths.

### DIFF
--- a/rmw/src/names_and_types.c
+++ b/rmw/src/names_and_types.c
@@ -58,7 +58,7 @@ rmw_names_and_types_init(
   RCUTILS_CAN_RETURN_WITH_ERROR_OF(RMW_RET_INVALID_ARGUMENT);
   RCUTILS_CAN_RETURN_WITH_ERROR_OF(RMW_RET_BAD_ALLOC);
 
-  if (!allocator) {
+  if (!rcutils_allocator_is_valid(allocator)) {
     RMW_SET_ERROR_MSG("allocator is null");
     return RMW_RET_INVALID_ARGUMENT;
   }

--- a/rmw/test/test_discovery_options.cpp
+++ b/rmw/test/test_discovery_options.cpp
@@ -32,11 +32,15 @@ TEST(discovery_options, init_invalid_args) {
   auto allocator = rcutils_get_default_allocator();
 
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_init(NULL, 0, &allocator));
+  rmw_reset_error();
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_init(&dopts, 0, NULL));
+  rmw_reset_error();
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_init(NULL, 0, NULL));
+  rmw_reset_error();
 
   EXPECT_EQ(RMW_RET_OK, rmw_discovery_options_init(&dopts_valid, 5, &allocator));
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_init(&dopts_valid, 5, &allocator));
+  rmw_reset_error();
 
   EXPECT_EQ(RMW_RET_OK, rmw_discovery_options_fini(&dopts_valid));
 }
@@ -131,13 +135,23 @@ TEST(discovery_options, copy_invalid_args) {
   EXPECT_EQ(RMW_RET_OK, rmw_discovery_options_init(&dopts1, 1, &allocator));
 
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_copy(NULL, &allocator, &dopts2));
+  rmw_reset_error();
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_copy(NULL, NULL, &dopts2));
+  rmw_reset_error();
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_copy(NULL, &allocator, NULL));
+  rmw_reset_error();
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_copy(NULL, NULL, NULL));
+  rmw_reset_error();
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_copy(&dopts1, NULL, &dopts2));
+  rmw_reset_error();
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_copy(&dopts1, NULL, NULL));
+  rmw_reset_error();
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_copy(&dopts1, &allocator, NULL));
+  rmw_reset_error();
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_copy(&dopts1, &allocator, &dopts1));
+  rmw_reset_error();
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_copy(&dopts2, &allocator, &dopts1));
+  rmw_reset_error();
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_discovery_options_copy(&dopts2, &allocator, &dopts2));
+  rmw_reset_error();
 }

--- a/rmw/test/test_names_and_types.cpp
+++ b/rmw/test/test_names_and_types.cpp
@@ -75,6 +75,13 @@ TEST(rmw_names_and_types, rmw_names_and_types_init) {
   EXPECT_EQ(result, RMW_RET_INVALID_ARGUMENT);
   rmw_reset_error();
 
+  // allocator is not null, but still invalid
+  rcutils_allocator_t invalid_allocator = get_time_bomb_allocator();
+  invalid_allocator.deallocate = nullptr;
+  result = rmw_names_and_types_init(&names_and_types, size, &invalid_allocator);
+  EXPECT_EQ(result, RMW_RET_INVALID_ARGUMENT);
+  rmw_reset_error();
+
   // names_and_types is null
   result = rmw_names_and_types_init(nullptr, size, &allocator);
   EXPECT_EQ(result, RMW_RET_INVALID_ARGUMENT);
@@ -95,7 +102,7 @@ TEST(rmw_names_and_types, rmw_names_and_types_init) {
 
   // Fails to deallocate names after failing to zero allocate types
   set_time_bomb_allocator_calloc_count(failing_allocator, 1);
-  failing_allocator.deallocate = nullptr;
+  set_time_bomb_allocator_free_count(failing_allocator, 1);
 
   // Logging is initialized during this code path and would need to be shutdown.
   ASSERT_EQ(rcutils_logging_initialize(), RCUTILS_RET_OK);

--- a/rmw/test/test_security_options.cpp
+++ b/rmw/test/test_security_options.cpp
@@ -41,20 +41,24 @@ TEST(rmw_security_options, options_copy) {
   EXPECT_EQ(
     RMW_RET_INVALID_ARGUMENT,
     rmw_security_options_copy(nullptr, &allocator, &destination));
+  rmw_reset_error();
 
   EXPECT_EQ(
     RMW_RET_INVALID_ARGUMENT,
     rmw_security_options_copy(&source, nullptr, &destination));
+  rmw_reset_error();
 
   EXPECT_EQ(
     RMW_RET_INVALID_ARGUMENT,
     rmw_security_options_copy(&source, &allocator, nullptr));
+  rmw_reset_error();
 
   rcutils_allocator_t failing_allocator = get_time_bomb_allocator();
   set_time_bomb_allocator_malloc_count(failing_allocator, 0);
   EXPECT_EQ(
     RMW_RET_BAD_ALLOC,
     rmw_security_options_copy(&source, &failing_allocator, &destination));
+  rmw_reset_error();
 
   EXPECT_EQ(
     RMW_RET_OK,

--- a/rmw/test/test_validate_namespace.cpp
+++ b/rmw/test/test_validate_namespace.cpp
@@ -24,8 +24,10 @@ TEST(test_validate_namespace, invalid_parameters) {
   size_t invalid_index;
   rmw_ret_t ret = rmw_validate_namespace(nullptr, &validation_result, &invalid_index);
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+  rmw_reset_error();
   ret = rmw_validate_namespace("/test", nullptr, &invalid_index);
   ASSERT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+  rmw_reset_error();
 
   // name is null pointer,
   ret = rmw_validate_namespace_with_size(nullptr, 0u, &validation_result, &invalid_index);


### PR DESCRIPTION
This mostly has to do with calling rmw_reset_error() in the proper time in the tests, but we also change one test for an allocator to properly check for a valid allocator.