### PR TITLE
Add rmw_isolation_{start,stop} API

### DIFF
--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -3342,6 +3342,38 @@ rmw_event_set_callback(
   rmw_event_callback_t callback,
   const void * user_data);
 
+/// Begin isolating ROS communication in this process.
+/**
+ * Perform neccessary changes to the process and/or environment so that any
+ * attempted ROS communication will be isolated from other processes.
+ *
+ * If the rmw implementation does not provide an implementation of this
+ * function, the default isolation mechanism changes the ROS_DOMAIN_ID to a
+ * value not already in use by the mechanism. This is typically sufficient to
+ * pass tests, but may not always be sufficient to fully isolate the test,
+ * which is why rmw implementations are encouraged to provide a stronger
+ * mechanism.
+ *
+ * \return `RMW_RET_OK` if successful, or
+ * \return `RMW_RET_ERROR` if an unexpected error occurs.
+ */
+RMW_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_isolation_start();
+
+/// Cease isolation of ROS communication in this process.
+/**
+ * Restore the process and/or environment to the previous state and deallocate
+ * any resources previously allocated by rmw_isolator_start().
+ *
+ * \return `RMW_RET_OK` if successful, or
+ * \return `RMW_RET_ERROR` if an unexpected error occurs.
+ */
+RMW_PUBLIC
+rmw_ret_t
+rmw_isolation_stop();
+
 #ifdef __cplusplus
 }
 #endif

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -3347,13 +3347,6 @@ rmw_event_set_callback(
  * Perform neccessary changes to the process and/or environment so that any
  * attempted ROS communication will be isolated from other processes.
  *
- * If the rmw implementation does not provide an implementation of this
- * function, the default isolation mechanism changes the ROS_DOMAIN_ID to a
- * value not already in use by the mechanism. This is typically sufficient to
- * pass tests, but may not always be sufficient to fully isolate the test,
- * which is why rmw implementations are encouraged to provide a stronger
- * mechanism.
- *
  * \return `RMW_RET_OK` if successful, or
  * \return `RMW_RET_ERROR` if an unexpected error occurs.
  */

--- a/rmw/include/rmw/rmw.h
+++ b/rmw/include/rmw/rmw.h
@@ -3360,7 +3360,7 @@ rmw_event_set_callback(
 RMW_PUBLIC
 RMW_WARN_UNUSED
 rmw_ret_t
-rmw_isolation_start();
+rmw_test_isolation_start();
 
 /// Cease isolation of ROS communication in this process.
 /**
@@ -3372,7 +3372,7 @@ rmw_isolation_start();
  */
 RMW_PUBLIC
 rmw_ret_t
-rmw_isolation_stop();
+rmw_test_isolation_stop();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
See in-code documentation for a description of what these functions are intended to do.

If we decide that this isn't something we'd like to include in the actual RMW API, it's possible to mirror the same pattern in a new set of packages and build these plugins as a separate binary from the actual RMW library. However, I'm proposing that we add it to the proper API to reduce duplication between this package and the alternative discrete set of packages.