### PR TITLE
Update link to rmw API docs

### DIFF
--- a/rmw/README.md
+++ b/rmw/README.md
@@ -5,7 +5,7 @@ The ROS 2 Middleware Interface provides an abstraction layer to different DDS im
 For more information, see https://design.ros2.org/articles/ros_middleware_interface.html
 
 ## Interface and Features
-For specific information about the rmw interface and features, see its [api docs](http://docs.ros2.org/latest/api/rmw/).
+For specific information about the rmw interface and features, see its [api docs](https://docs.ros.org/en/rolling/p/rmw/generated/).
 
 ## Quality Declaration
 


### PR DESCRIPTION
## Description

Package docs are now at `docs.ros.org/en/$distro/p/$pkg/`. The `rmw` API generated docs are at https://docs.ros.org/en/rolling/p/rmw/generated/.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
