### PR TITLE
Remove default from switch with enum, so that compiler warns.

### DIFF
--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -461,10 +461,6 @@ typedef enum RMW_PUBLIC_TYPE rmw_qos_durability_policy_e
   RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE
 } rmw_qos_durability_policy_t;
 
-#define RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE_DEPRECATED_MSG \
-  "RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE is deprecated. " \
-  "Use RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC if manually asserted liveliness is needed."
-
 #ifndef _MSC_VER
 # define RMW_DECLARE_DEPRECATED(name, msg) name __attribute__((deprecated(msg)))
 #else
@@ -482,13 +478,6 @@ typedef enum RMW_PUBLIC_TYPE rmw_qos_liveliness_policy_e
 
   /// The signal that establishes a Topic is alive comes from the ROS rmw layer.
   RMW_QOS_POLICY_LIVELINESS_AUTOMATIC = 1,
-
-  /// Explicitly asserting node liveliness is required in this case.
-  /// This option is deprecated, use RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC if your application
-  /// requires to assert liveliness manually.
-  RMW_DECLARE_DEPRECATED(
-    RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE,
-    RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE_DEPRECATED_MSG) = 2,
 
   /// The signal that establishes a Topic is alive is at the Topic level. Only publishing a message
   /// on the Topic or an explicit signal from the application to assert liveliness on the Topic

--- a/rmw/src/qos_string_conversions.c
+++ b/rmw/src/qos_string_conversions.c
@@ -37,10 +37,10 @@ rmw_qos_policy_kind_to_str(rmw_qos_policy_kind_t kind)
       return "liveliness_lease_duration";
     case RMW_QOS_POLICY_AVOID_ROS_NAMESPACE_CONVENTIONS:
       return "avoid_ros_namespace_conventions";
-    case RMW_QOS_POLICY_INVALID:  // fallthrough
-    default:
+    case RMW_QOS_POLICY_INVALID:
       return NULL;
   }
+  return NULL;
 }
 
 const char *
@@ -55,10 +55,10 @@ rmw_qos_durability_policy_to_str(enum rmw_qos_durability_policy_e value)
       return "volatile";
     case RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE:
       return "best_available";
-    case RMW_QOS_POLICY_DURABILITY_UNKNOWN:  // fallthrough
-    default:
+    case RMW_QOS_POLICY_DURABILITY_UNKNOWN:
       return NULL;
   }
+  return NULL;
 }
 
 const char *
@@ -71,10 +71,10 @@ rmw_qos_history_policy_to_str(enum rmw_qos_history_policy_e value)
       return "keep_last";
     case RMW_QOS_POLICY_HISTORY_KEEP_ALL:
       return "keep_all";
-    case RMW_QOS_POLICY_HISTORY_UNKNOWN:  // fallthrough
-    default:
+    case RMW_QOS_POLICY_HISTORY_UNKNOWN:
       return NULL;
   }
+  return NULL;
 }
 
 const char *
@@ -89,10 +89,10 @@ rmw_qos_liveliness_policy_to_str(enum rmw_qos_liveliness_policy_e value)
       return "manual_by_topic";
     case RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE:
       return "best_available";
-    case RMW_QOS_POLICY_LIVELINESS_UNKNOWN:  // fallthrough
-    default:
+    case RMW_QOS_POLICY_LIVELINESS_UNKNOWN:
       return NULL;
   }
+  return NULL;
 }
 
 const char *
@@ -107,10 +107,10 @@ rmw_qos_reliability_policy_to_str(enum rmw_qos_reliability_policy_e value)
       return "best_effort";
     case RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE:
       return "best_available";
-    case RMW_QOS_POLICY_RELIABILITY_UNKNOWN:  // fallthrough
-    default:
+    case RMW_QOS_POLICY_RELIABILITY_UNKNOWN:
       return NULL;
   }
+  return NULL;
 }
 
 #define RMW_QOS_STREQ_WITH_LITERAL(string_literal, string) \


### PR DESCRIPTION
## Description

Now the compiler will warn us if new enum values are added to it but aren't handled in this function.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

Yes, actually this includes ABI breaking change that removes the deprecated enum member.
That means offset of the data structure has been changed, this breaks the user space and it needs to be rebuilt.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

> [!WARNING]
> DO NOT BACKPORT THIS, THIS IS ABI BREAKING CHANGE.