### PR TITLE
Add is_cft_supported field to rmw_subscription_t for content filtering support

### DIFF
--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -213,6 +213,9 @@ typedef struct RMW_PUBLIC_TYPE rmw_subscription_s
 
   /// Indicates whether content filtered topic of this subscription is enabled
   bool is_cft_enabled;
+
+  /// Indicates whether the subscription support content filtered topic feature
+  bool is_cft_supported;
 } rmw_subscription_t;
 
 /// A handle to an rmw service

--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -214,7 +214,7 @@ typedef struct RMW_PUBLIC_TYPE rmw_subscription_s
   /// Indicates whether content filtered topic of this subscription is enabled
   bool is_cft_enabled;
 
-  /// Indicates whether the subscription support content filtered topic feature
+  /// Indicates whether this subscription supports content filtered topic feature
   bool is_cft_supported;
 } rmw_subscription_t;
 


### PR DESCRIPTION
## Description

Add a new field to indicate whether RMW supports the content filter feature.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

Currently, there is no RMW interface to check whether the content filter feature is supported. Currently, the code at the RCL layer uses a workaround to determine whether RMW supports content filtering and configures this value accordingly.  
Refer to ros2/rcl#1293