### PR TITLE
Add acceptable_buffer_backends field in rmw_subscription_options_s

### DIFF
--- a/rmw/include/rmw/types.h
+++ b/rmw/include/rmw/types.h
@@ -184,6 +184,17 @@ typedef struct RMW_PUBLIC_TYPE rmw_subscription_options_s
 
   /// Used to create a content filter options during subscription creation.
   rmw_subscription_content_filter_options_t * content_filter_options;
+
+  /// Comma-separated list of acceptable buffer backend names for this endpoint.
+  /**
+   * NULL, empty string, or "cpu" all mean CPU-only (default for backward compat).
+   * "any" means all installed backends are acceptable.
+   * Comma-separated for specific backends, e.g. "cuda,demo".
+   * CPU is always implicitly acceptable regardless of this value.
+   * The RMW will validate that each specified backend is installed and will
+   * report an error if any are not available.
+   */
+  const char * acceptable_buffer_backends;
 } rmw_subscription_options_t;
 
 typedef struct RMW_PUBLIC_TYPE rmw_subscription_s

--- a/rmw/src/subscription_options.c
+++ b/rmw/src/subscription_options.c
@@ -27,6 +27,7 @@ rmw_get_default_subscription_options(void)
     .ignore_local_publications = false,
     .require_unique_network_flow_endpoints = RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_NOT_REQUIRED,
     .content_filter_options = NULL,
+    .acceptable_buffer_backends = "cpu",
   };
   return subscription_options;
 }

--- a/rmw/src/subscription_options.c
+++ b/rmw/src/subscription_options.c
@@ -27,7 +27,7 @@ rmw_get_default_subscription_options(void)
     .ignore_local_publications = false,
     .require_unique_network_flow_endpoints = RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_NOT_REQUIRED,
     .content_filter_options = NULL,
-    .acceptable_buffer_backends = "cpu",
+    .acceptable_buffer_backends = NULL,
   };
   return subscription_options;
 }

--- a/rmw/test/test_subscription_options.cpp
+++ b/rmw/test/test_subscription_options.cpp
@@ -25,5 +25,5 @@ TEST(rmw_subscription_options, get_default_subscription_options)
     options.require_unique_network_flow_endpoints,
     RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_NOT_REQUIRED);
   EXPECT_EQ(options.content_filter_options, nullptr);
-  EXPECT_STREQ(options.acceptable_buffer_backends, "cpu");
+  EXPECT_EQ(options.acceptable_buffer_backends, nullptr);
 }

--- a/rmw/test/test_subscription_options.cpp
+++ b/rmw/test/test_subscription_options.cpp
@@ -25,4 +25,5 @@ TEST(rmw_subscription_options, get_default_subscription_options)
     options.require_unique_network_flow_endpoints,
     RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_NOT_REQUIRED);
   EXPECT_EQ(options.content_filter_options, nullptr);
+  EXPECT_STREQ(options.acceptable_buffer_backends, "cpu");
 }


### PR DESCRIPTION
## Description

This pull request adds the `acceptable_buffer_backends` subscription option in RMW layer. This option allows subscribers to control which buffer backends they accept, with a backward-compatible default of CPU-only.

This pull request consists of the following key changes:

- **`rmw`** (`types.h`): Adds a new field `acceptable_buffer_backends` (const char *) on `rmw_subscription_options_t`. `NULL`, empty string, or `"cpu"` means CPU-only (backward-compatible default); `"any"` means all installed backends; comma-separated names (e.g. `"cuda,demo"`) restrict to those specific backends. `rmw_get_default_subscription_options()` sets the default to `"cpu"`. 

### Is this user-facing behavior change?

The default value `"cpu"` preserves existing behavior -- subscriptions only accept CPU-based data unless explicitly opting in. This is a new API surface but is additive and backward-compatible. Existing code that does not pass `acceptable_buffer_backends` will behave identically to before.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

This PR is part of the broader ROS 2 native buffer feature introduced in this [post](https://discourse.openrobotics.org/t/working-prototype-of-native-buffers-accelerated-memory-transport/52399). 