### PR TITLE
find_package ament_cmake_gtest

### DIFF
--- a/rmw/test/CMakeLists.txt
+++ b/rmw/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(ament_cmake_gmock REQUIRED)
+find_package(ament_cmake_gtest REQUIRED)
 find_package(osrf_testing_tools_cpp REQUIRED)
 
 


### PR DESCRIPTION
## Description

This subdirectory uses ament_add_gtest, but does not find_package to get access to the macro.

Part of https://github.com/ament/googletest/issues/37

Uncovered by https://github.com/ament/ament_cmake/pull/622


### Is this user-facing behavior change?


### Did you use Generative AI?

no

### Additional Information

Part of deprecating gtest_vendor and gmock_vendor in ROS Lyrical
