### PR TITLE
Add missing <stdbool.h> include to time.h

### DIFF
--- a/rmw/include/rmw/time.h
+++ b/rmw/include/rmw/time.h
@@ -20,6 +20,7 @@ extern "C"
 {
 #endif  // __cplusplus
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "rcutils/time.h"


### PR DESCRIPTION
`rmw/include/rmw/time.h` uses `bool` as the return type of `rmw_time_equal()` (line 60) but does not include `<stdbool.h>`. This previously worked because `rcutils/time.h` transitively pulled in `<stdbool.h>` via `rcutils/types.h` → `hash_map.h` → `allocator.h`.

After ros2/rcutils#580 (commit 47a44cb, backported to jazzy as #583) narrowed the include in `rcutils/time.h` from `rcutils/types.h` to `rcutils/types/rcutils_ret.h`, this transitive chain is broken. Any C translation unit that includes `rmw/time.h` now fails to compile:

```
  rmw/include/rmw/time.h:60:1: error: unknown type name 'bool'
     60 | bool
        | ^~~~
```

The fix is to add #include <stdbool.h> to rmw/time.h.

## Verification

```c
  /* C translation unit that includes rmw/time.h */
  #include "rmw/time.h"

  void test_func(void) {
      rmw_time_t a = {0, 0};
      rmw_time_t b = {0, 0};
      bool result = rmw_time_equal(a, b);
      (void)result;
  }
```
* Create a minimal colcon workspace with `rcutils:jazzy` and `rmw:jazzy` (unfixed) and the above C file in a test C package
* `colcon build` in the workspace reproduced the above error
* Changing the rmw package to include the fix in this MR allowed the build to succeed.

## Did you use Generative AI?
Claude Opus 4.6